### PR TITLE
feat: add max-listener guard and listenerCount to RuntimeEventBus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1229,7 +1229,6 @@
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1279,7 +1278,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -1672,7 +1670,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2006,7 +2003,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2884,7 +2880,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3396,7 +3391,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3550,7 +3544,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/src/events/__tests__/runtime-events.test.ts
+++ b/src/events/__tests__/runtime-events.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RuntimeEventBus } from '../runtime-events';
+
+describe('RuntimeEventBus max listeners', () => {
+  it('warns when exceeding maxListenersPerEvent', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bus = new RuntimeEventBus(2);
+
+    bus.on('runtime.started', () => {});
+    bus.on('runtime.started', () => {});
+    bus.on('runtime.started', () => {});
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('Max listener limit (2) exceeded');
+    warnSpy.mockRestore();
+  });
+
+  it('exposes listenerCount', () => {
+    const bus = new RuntimeEventBus();
+    expect(bus.listenerCount('runtime.started')).toBe(0);
+
+    const unsub = bus.on('runtime.started', () => {});
+    expect(bus.listenerCount('runtime.started')).toBe(1);
+
+    unsub();
+    expect(bus.listenerCount('runtime.started')).toBe(0);
+  });
+
+  it('defaults to 100 max listeners', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bus = new RuntimeEventBus();
+
+    for (let i = 0; i < 101; i++) {
+      bus.on('runtime.started', () => {});
+    }
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+});

--- a/src/events/runtime-events.ts
+++ b/src/events/runtime-events.ts
@@ -37,12 +37,25 @@ export class RuntimeEventBus {
     RuntimeEventName,
     Set<RuntimeEventListener<RuntimeEventName>>
   >();
+  private readonly maxListenersPerEvent: number;
+
+  public constructor(maxListenersPerEvent: number = 100) {
+    this.maxListenersPerEvent = maxListenersPerEvent;
+  }
 
   public on<TName extends RuntimeEventName>(
     name: TName,
     listener: RuntimeEventListener<TName>
   ): () => void {
     const existing = this.listeners.get(name) ?? new Set();
+    
+    if (existing.size >= this.maxListenersPerEvent) {
+      console.warn(
+        `RuntimeEventBus: Max listener limit (${this.maxListenersPerEvent}) exceeded for event "${name}". ` +
+        `Possible memory leak. Current count: ${existing.size}`
+      );
+    }
+
     existing.add(listener as RuntimeEventListener<RuntimeEventName>);
     this.listeners.set(name, existing);
 
@@ -59,5 +72,9 @@ export class RuntimeEventBus {
     listeners?.forEach((listener) => {
       listener(event);
     });
+  }
+
+  public listenerCount(name: RuntimeEventName): number {
+    return this.listeners.get(name)?.size ?? 0;
   }
 }


### PR DESCRIPTION
## Summary

Adds a configurable  limit (default 100) to  that warns when exceeded, plus a  getter.

## Motivation

As described in #138, the event bus had no listener-count limit. Consumers leaking subscriptions would grow the internal  indefinitely, degrading emit performance and potentially causing memory issues.

## Changes

- Added  constructor parameter (default 100).
-  now warns via  when adding a listener would exceed the limit.
- Added  method returning current listener count for an event.
- Added 3 unit tests covering warning behavior, listenerCount accuracy, and default limit.
- All tests pass via vitest.

Closes #138.