### PR TITLE
Fix #139: [Bounty: $100] Add runtime.internal.error event for listener failures

### DIFF
--- a/src/events/runtime-events.ts
+++ b/src/events/runtime-events.ts
@@ -1,4 +1,8 @@
 export interface RuntimeEventMap {
+  "runtime.internal.error": {
+    eventName: RuntimeEventName;
+    message: string;
+  };
   "runtime.started": { runtimeId: string; occurredAt: string };
   "runtime.task.received": {
     runtimeId: string;
@@ -57,7 +61,19 @@ export class RuntimeEventBus {
     const listeners = this.listeners.get(event.name);
 
     listeners?.forEach((listener) => {
-      listener(event);
+      try {
+        listener(event);
+      } catch (error) {
+        if (event.name !== "runtime.internal.error") {
+          this.emit({
+            name: "runtime.internal.error",
+            payload: {
+              eventName: event.name,
+              message: error instanceof Error ? error.message : String(error)
+            }
+          });
+        }
+      }
     });
   }
 }

--- a/tests/runtime-events.test.ts
+++ b/tests/runtime-events.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { RuntimeEventBus } from "../src/index.js";
+
+describe("RuntimeEventBus", () => {
+  it("isolates listener failures and emits an internal error event", () => {
+    const eventBus = new RuntimeEventBus();
+    const unaffectedListener = vi.fn();
+    const internalErrors: Array<{
+      eventName: string;
+      message: string;
+    }> = [];
+
+    eventBus.on("runtime.started", () => {
+      throw new Error("listener failed");
+    });
+    eventBus.on("runtime.started", unaffectedListener);
+    eventBus.on("runtime.internal.error", (event) => {
+      internalErrors.push(event.payload);
+    });
+
+    expect(() =>
+      eventBus.emit({
+        name: "runtime.started",
+        payload: { runtimeId: "runtime-test", occurredAt: "2025-01-01" }
+      })
+    ).not.toThrow();
+
+    expect(unaffectedListener).toHaveBeenCalledOnce();
+    expect(internalErrors).toEqual([
+      { eventName: "runtime.started", message: "listener failed" }
+    ]);
+  });
+});


### PR DESCRIPTION
Addresses #139.

Added the typed runtime.internal.error event and isolated listener failures so the bus reports the affected event name and original error message while continuing delivery to other listeners. Added focused regression coverage.

Submitted by TheOMKGroup.