### PR TITLE
Fix #138: [Bounty: $100] Add max-listener guard to RuntimeEventBus

### DIFF
--- a/src/events/runtime-events.ts
+++ b/src/events/runtime-events.ts
@@ -32,23 +32,71 @@ export type RuntimeEventListener<TName extends RuntimeEventName> = (
   event: RuntimeEvent<TName>
 ) => void;
 
+export interface RuntimeEventBusOptions {
+  /** Maximum number of listeners allowed for each event name. */
+  maxListeners?: number;
+}
+
+export class RuntimeEventListenerLimitError extends Error {
+  public readonly eventName: RuntimeEventName;
+  public readonly maxListeners: number;
+
+  public constructor(eventName: RuntimeEventName, maxListeners: number) {
+    super(
+      `Cannot add listener for "${eventName}": the limit of ${maxListeners} listeners has been reached.`
+    );
+    this.name = "RuntimeEventListenerLimitError";
+    this.eventName = eventName;
+    this.maxListeners = maxListeners;
+  }
+}
+
 export class RuntimeEventBus {
+  public static readonly defaultMaxListeners = 100;
+
   private readonly listeners = new Map<
     RuntimeEventName,
     Set<RuntimeEventListener<RuntimeEventName>>
   >();
+  private readonly maxListeners: number;
+
+  public constructor(options: RuntimeEventBusOptions = {}) {
+    const maxListeners =
+      options.maxListeners ?? RuntimeEventBus.defaultMaxListeners;
+
+    if (!Number.isInteger(maxListeners) || maxListeners < 1) {
+      throw new RangeError("maxListeners must be a positive integer.");
+    }
+
+    this.maxListeners = maxListeners;
+  }
 
   public on<TName extends RuntimeEventName>(
     name: TName,
     listener: RuntimeEventListener<TName>
   ): () => void {
     const existing = this.listeners.get(name) ?? new Set();
-    existing.add(listener as RuntimeEventListener<RuntimeEventName>);
+    const runtimeListener =
+      listener as RuntimeEventListener<RuntimeEventName>;
+
+    if (!existing.has(runtimeListener) && existing.size >= this.maxListeners) {
+      throw new RuntimeEventListenerLimitError(name, this.maxListeners);
+    }
+
+    existing.add(runtimeListener);
     this.listeners.set(name, existing);
 
     return () => {
-      existing.delete(listener as RuntimeEventListener<RuntimeEventName>);
+      existing.delete(runtimeListener);
+
+      if (existing.size === 0) {
+        this.listeners.delete(name);
+      }
     };
+  }
+
+  public listenerCount(name: RuntimeEventName): number {
+    return this.listeners.get(name)?.size ?? 0;
   }
 
   public emit<TName extends RuntimeEventName>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,10 @@ export type { RuntimeOptions } from "./runtime/types.js";
 export { AgentInstanceManager } from "./agents/agent-instance-manager.js";
 export { ActionExecutor } from "./actions/action-executor.js";
 export { RuntimeError } from "./errors/runtime-errors.js";
-export { RuntimeEventBus } from "./events/runtime-events.js";
+export {
+  RuntimeEventBus,
+  RuntimeEventListenerLimitError
+} from "./events/runtime-events.js";
 export { InMemoryRuntimeLogger } from "./logger/runtime-logger.js";
 export { InMemoryMemoryStore } from "./memory/memory-store.js";
 export { UnconfiguredModelProvider } from "./providers/model-provider.js";
@@ -19,6 +22,8 @@ export type { AgentInstance } from "./agents/agent-instance-manager.js";
 export type { RuntimeErrorCode } from "./errors/runtime-errors.js";
 export type {
   RuntimeEvent,
+  RuntimeEventBusOptions,
+  RuntimeEventListener,
   RuntimeEventMap,
   RuntimeEventName
 } from "./events/runtime-events.js";

--- a/tests/runtime-events.test.ts
+++ b/tests/runtime-events.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  RuntimeEventBus,
+  RuntimeEventListenerLimitError
+} from "../src/index.js";
+
+describe("RuntimeEventBus", () => {
+  it("tracks listener counts and updates them when unsubscribed", () => {
+    const eventBus = new RuntimeEventBus();
+    const unsubscribe = eventBus.on("runtime.started", vi.fn());
+
+    expect(eventBus.listenerCount("runtime.started")).toBe(1);
+    expect(eventBus.listenerCount("runtime.task.failed")).toBe(0);
+
+    unsubscribe();
+    expect(eventBus.listenerCount("runtime.started")).toBe(0);
+  });
+
+  it("throws a typed error before exceeding the configured per-event limit", () => {
+    const eventBus = new RuntimeEventBus({ maxListeners: 1 });
+    eventBus.on("runtime.started", vi.fn());
+
+    expect(() => eventBus.on("runtime.started", vi.fn())).toThrowError(
+      RuntimeEventListenerLimitError
+    );
+    expect(eventBus.listenerCount("runtime.started")).toBe(1);
+
+    // The limit applies independently to each event name.
+    expect(() => eventBus.on("runtime.task.failed", vi.fn())).not.toThrow();
+  });
+
+  it("does not reject the same listener when it is already registered", () => {
+    const eventBus = new RuntimeEventBus({ maxListeners: 1 });
+    const listener = vi.fn();
+
+    eventBus.on("runtime.started", listener);
+    expect(() => eventBus.on("runtime.started", listener)).not.toThrow();
+    expect(eventBus.listenerCount("runtime.started")).toBe(1);
+  });
+
+  it.each([0, -1, 1.5, Number.NaN])(
+    "rejects invalid maxListeners value %s",
+    (maxListeners) => {
+      expect(() => new RuntimeEventBus({ maxListeners })).toThrow(RangeError);
+    }
+  );
+});


### PR DESCRIPTION
Addresses #138.

Added a configurable per-event max-listener guard (default 100), a typed RuntimeEventListenerLimitError, listenerCount(name), public exports, and focused unit coverage.

Submitted by TheOMKGroup.