### PR TITLE
test(memory): add property-based tests for InMemoryMemoryStore append/list invariants (bounty #153)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.27.0",
         "eslint-config-prettier": "^10.1.5",
+        "fast-check": "^4.9.0",
         "globals": "^16.1.0",
         "prettier": "^3.5.3",
         "typescript": "^5.8.3",
@@ -1229,7 +1230,6 @@
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1279,7 +1279,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -1672,7 +1671,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2006,7 +2004,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2189,6 +2186,29 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2884,7 +2904,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2956,6 +2975,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3396,7 +3432,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3550,7 +3585,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.27.0",
     "eslint-config-prettier": "^10.1.5",
+    "fast-check": "^4.9.0",
     "globals": "^16.1.0",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",

--- a/tests/memory-store.test.ts
+++ b/tests/memory-store.test.ts
@@ -1,0 +1,105 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { InMemoryMemoryStore, type MemoryEntry } from "../src/index.js";
+
+const AGENT_IDS = [
+  "agent-alpha",
+  "agent-beta",
+  "agent-gamma",
+  "agent-delta"
+] as const;
+
+const entryArb: fc.Arbitrary<MemoryEntry> = fc.record({
+  agentId: fc.constantFrom(...AGENT_IDS),
+  taskId: fc.string({ maxLength: 32 }),
+  input: fc.string({ maxLength: 64 }),
+  output: fc.oneof(fc.string({ maxLength: 64 }), fc.integer(), fc.boolean()),
+  recordedAt: fc
+    .date()
+    .filter((date) => !Number.isNaN(date.getTime()))
+    .map((date) => date.toISOString())
+});
+
+describe("InMemoryMemoryStore property-based invariants", () => {
+  it("listByAgent returns exactly the appended entries for the agent, in append order", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(entryArb, { maxLength: 150 }),
+        fc.constantFrom(...AGENT_IDS),
+        async (entries, probeAgent) => {
+          const store = new InMemoryMemoryStore();
+          for (const entry of entries) {
+            await store.append(entry);
+          }
+
+          const actual = await store.listByAgent(probeAgent);
+          const expected = entries.filter(
+            (entry) => entry.agentId === probeAgent
+          );
+
+          // Per-agent filter correctness: entries from other agents never leak in.
+          expect(actual.every((entry) => entry.agentId === probeAgent)).toBe(
+            true
+          );
+          // Append-order invariant: results keep the relative append sequence.
+          expect(actual).toEqual(expected);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  it("later appends extend earlier snapshots without reordering them", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(entryArb, { maxLength: 120 }),
+        fc.constantFrom(...AGENT_IDS),
+        async (entries, probeAgent) => {
+          const store = new InMemoryMemoryStore();
+          const splitAt = Math.floor(entries.length / 2);
+
+          for (const entry of entries.slice(0, splitAt)) {
+            await store.append(entry);
+          }
+          const snapshot = await store.listByAgent(probeAgent);
+          expect(snapshot).toEqual(
+            entries
+              .slice(0, splitAt)
+              .filter((entry) => entry.agentId === probeAgent)
+          );
+
+          for (const entry of entries.slice(splitAt)) {
+            await store.append(entry);
+          }
+          const later = await store.listByAgent(probeAgent);
+          // Previously observed entries stay in front, in the same relative order.
+          expect(later.slice(0, snapshot.length)).toEqual(snapshot);
+          expect(later).toEqual(
+            entries.filter((entry) => entry.agentId === probeAgent)
+          );
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  it("returns an empty list for agents with no entries, even after appends", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(entryArb, { maxLength: 80 }),
+        async (entries) => {
+          const store = new InMemoryMemoryStore();
+          for (const entry of entries) {
+            await store.append(entry);
+          }
+          const used = new Set(entries.map((entry) => entry.agentId));
+          const unused = AGENT_IDS.find((id) => !used.has(id));
+          if (unused !== undefined) {
+            expect(await store.listByAgent(unused)).toEqual([]);
+          }
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+});


### PR DESCRIPTION
Fixes #153 ([Bounty: $95] Add property-based tests for memory store append/list invariants)

## What
Adds `tests/memory-store.test.ts` with property-based tests (via `fast-check`) for `InMemoryMemoryStore` append/list invariants, as requested in the issue.

## Acceptance criteria
- [x] **Randomized append sequences covered** — each property runs 100 randomized rounds (50 for the empty-agent case) of arbitrary append sequences across 4 agents
- [x] **Append-order invariant asserted** — `listByAgent` returns entries in the exact append order (also verified incrementally: later appends extend earlier snapshots without reordering)
- [x] **Per-agent filter correctness asserted** — results contain exactly the entries appended for the queried agent; entries from other agents never leak in; agents with no entries get `[]`

## Verification (local)
- `npx tsc --noEmit` — clean
- `npx eslint src tests vitest.config.ts` — clean
- `npx vitest run` — 4 files, 9 tests passed (3 new property tests, 250 randomized rounds total)
- New test file passes `prettier --check`