### PR TITLE
feat: log task execution duration in TaskRunner (Closes #141)

### DIFF
--- a/src/runtime/agent-runtime.ts
+++ b/src/runtime/agent-runtime.ts
@@ -80,13 +80,21 @@ export class AgentRuntime {
         context
       );
 
+      this.dependencies.logger.info("Runtime task completed.", {
+        runtimeId: this.runtimeId,
+        taskId: task.taskId,
+        toolName: task.toolName,
+        durationMs: result.durationMs
+      });
+
       this.dependencies.eventBus.emit({
         name: "runtime.task.completed",
         payload: {
           runtimeId: this.runtimeId,
           taskId: task.taskId,
           agentId: task.agentId,
-          toolName: task.toolName
+          toolName: task.toolName,
+          durationMs: result.durationMs
         }
       });
 

--- a/src/tasks/task-runner.ts
+++ b/src/tasks/task-runner.ts
@@ -20,6 +20,8 @@ export class TaskRunner {
     assertNonEmptyValue(task.toolName, "toolName");
     assertNonEmptyValue(task.input, "input");
 
+    const startedAt = new Date();
+
     try {
       const output = await this.actionExecutor.execute<TPayload, TResult>(
         task.toolName,
@@ -27,14 +29,15 @@ export class TaskRunner {
         context
       );
 
-      const completedAt = new Date().toISOString();
+      const completedAt = new Date();
+      const durationMs = Math.max(0, completedAt.getTime() - startedAt.getTime());
 
       await this.memoryStore.append({
         agentId: task.agentId,
         taskId: task.taskId,
         input: task.input,
         output,
-        recordedAt: completedAt
+        recordedAt: completedAt.toISOString()
       });
 
       return {
@@ -42,7 +45,9 @@ export class TaskRunner {
         agentId: task.agentId,
         toolName: task.toolName,
         output,
-        completedAt
+        startedAt: startedAt.toISOString(),
+        completedAt: completedAt.toISOString(),
+        durationMs
       };
     } catch (error) {
       if (error instanceof RuntimeError) {

--- a/src/tasks/task-types.ts
+++ b/src/tasks/task-types.ts
@@ -11,5 +11,8 @@ export interface TaskExecutionResult<TResult = unknown> {
   agentId: string;
   toolName: string;
   output: TResult;
+  startedAt: string;
   completedAt: string;
+  /** Duration of task execution in milliseconds. Always >= 0. */
+  durationMs: number;
 }

--- a/tests/runtime/log-task-duration.test.ts
+++ b/tests/runtime/log-task-duration.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AgentRuntime } from '../../src/runtime/agent-runtime.js';
+
+describe('Task execution duration logging', () => {
+  it('includes durationMs in completion log and event', async () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    const events: any[] = [];
+    const eventBus = {
+      emit: vi.fn((e: any) => events.push(e)),
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+
+    const runtime = new AgentRuntime({
+      runtimeId: 'test-log-duration',
+      logger: logger as any,
+      eventBus: eventBus as any,
+      tools: [],
+      modelProvider: { generate: vi.fn() } as any,
+    });
+
+    runtime.registerTool({
+      name: 'echo',
+      description: 'Echo tool',
+      inputSchema: { type: 'object', properties: {} },
+      execute: vi.fn(async () => ({ echoed: true })),
+    });
+
+    await runtime.start();
+
+    const result = await runtime.executeTask({
+      taskId: 'task-log-1',
+      agentId: 'agent-1',
+      toolName: 'echo',
+      input: 'test',
+      payload: {},
+    });
+
+    // Verify result has durationMs (from #136)
+    expect(result.durationMs).toBeDefined();
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+
+    // Verify completion log includes durationMs
+    const completionLog = logger.info.mock.calls.find(
+      (call: any[]) => typeof call[0] === 'string' && call[0].includes('completed')
+    );
+    expect(completionLog).toBeDefined();
+    expect(completionLog![1]).toHaveProperty('durationMs');
+    expect(completionLog![1].durationMs).toBe(result.durationMs);
+
+    // Verify completion event includes durationMs
+    const completedEvent = events.find((e) => e.name === 'runtime.task.completed');
+    expect(completedEvent).toBeDefined();
+    expect(completedEvent.payload).toHaveProperty('durationMs');
+    expect(completedEvent.payload.durationMs).toBe(result.durationMs);
+  });
+});

--- a/tests/tasks/task-duration.test.ts
+++ b/tests/tasks/task-duration.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TaskRunner } from '../../src/tasks/task-runner.js';
+import type { ActionExecutor } from '../../src/actions/action-executor.js';
+import type { MemoryStore } from '../../src/memory/memory-store.js';
+import type { RuntimeContext } from '../../src/runtime/context.js';
+import type { RuntimeTask } from '../../src/tasks/task-types.js';
+
+function makeMockActionExecutor(delayMs: number = 0): ActionExecutor {
+  return {
+    execute: vi.fn(async () => {
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+      return { result: 'success' };
+    }),
+  } as unknown as ActionExecutor;
+}
+
+function makeMockMemoryStore(): MemoryStore {
+  return {
+    append: vi.fn(async () => {}),
+  } as unknown as MemoryStore;
+}
+
+function makeTask(overrides: Partial<RuntimeTask> = {}): RuntimeTask {
+  return {
+    taskId: 'task-1',
+    agentId: 'agent-1',
+    toolName: 'test-tool',
+    input: 'test input',
+    payload: {},
+    ...overrides,
+  };
+}
+
+const mockContext = {} as RuntimeContext;
+
+describe('TaskExecutionResult duration fields', () => {
+  it('includes startedAt and durationMs in the result', async () => {
+    const runner = new TaskRunner(makeMockActionExecutor(), makeMockMemoryStore());
+    const result = await runner.run(makeTask(), mockContext);
+
+    expect(result.startedAt).toBeDefined();
+    expect(typeof result.startedAt).toBe('string');
+    expect(new Date(result.startedAt).toISOString()).toBe(result.startedAt);
+
+    expect(result.durationMs).toBeDefined();
+    expect(typeof result.durationMs).toBe('number');
+  });
+
+  it('durationMs is always >= 0', async () => {
+    const runner = new TaskRunner(makeMockActionExecutor(), makeMockMemoryStore());
+    const result = await runner.run(makeTask(), mockContext);
+
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('durationMs reflects actual execution time', async () => {
+    const delayMs = 50;
+    const runner = new TaskRunner(makeMockActionExecutor(delayMs), makeMockMemoryStore());
+    const result = await runner.run(makeTask(), mockContext);
+
+    expect(result.durationMs).toBeGreaterThanOrEqual(delayMs - 10);
+    expect(result.durationMs).toBeLessThan(delayMs + 200);
+  });
+
+  it('startedAt is before completedAt', async () => {
+    const runner = new TaskRunner(makeMockActionExecutor(10), makeMockMemoryStore());
+    const result = await runner.run(makeTask(), mockContext);
+
+    const started = new Date(result.startedAt).getTime();
+    const completed = new Date(result.completedAt).getTime();
+
+    expect(started).toBeLessThanOrEqual(completed);
+  });
+});


### PR DESCRIPTION
## Summary
Adds `durationMs` to the completion log and `runtime.task.completed` event payload in `AgentRuntime.executeTask`. This builds on PR #165 (issue #136) which added the `durationMs` field to `TaskExecutionResult`, making task timing observable in logs and event streams without extra instrumentation.

Depends on PR #165 (issue #136 - durationMs field).

## Changes
- Updated `src/runtime/agent-runtime.ts` to log `durationMs` via `logger.info` on task completion
- Added `durationMs` to the `runtime.task.completed` event payload
- Added 1 test in `tests/runtime/log-task-duration.test.ts` verifying `durationMs` appears in both the logger call and emitted event

## Testing
All 11 tests pass (5 test files). TypeScript compiles clean.

Closes #141