### PR TITLE
feat: add warn and debug levels to RuntimeLogger (Closes #132)

### DIFF
--- a/src/logger/runtime-logger.ts
+++ b/src/logger/runtime-logger.ts
@@ -1,11 +1,21 @@
 export interface RuntimeLogger {
   info(message: string, metadata?: Record<string, unknown>): void;
+  warn(message: string, metadata?: Record<string, unknown>): void;
+  debug(message: string, metadata?: Record<string, unknown>): void;
   error(message: string, metadata?: Record<string, unknown>): void;
 }
 
 export class ConsoleRuntimeLogger implements RuntimeLogger {
   public info(message: string, metadata?: Record<string, unknown>): void {
     console.info(message, metadata ?? {});
+  }
+
+  public warn(message: string, metadata?: Record<string, unknown>): void {
+    console.warn(message, metadata ?? {});
+  }
+
+  public debug(message: string, metadata?: Record<string, unknown>): void {
+    console.debug(message, metadata ?? {});
   }
 
   public error(message: string, metadata?: Record<string, unknown>): void {
@@ -15,13 +25,21 @@ export class ConsoleRuntimeLogger implements RuntimeLogger {
 
 export class InMemoryRuntimeLogger implements RuntimeLogger {
   public readonly entries: Array<{
-    level: "info" | "error";
+    level: "info" | "warn" | "debug" | "error";
     message: string;
     metadata: Record<string, unknown> | undefined;
   }> = [];
 
   public info(message: string, metadata?: Record<string, unknown>): void {
     this.entries.push({ level: "info", message, metadata });
+  }
+
+  public warn(message: string, metadata?: Record<string, unknown>): void {
+    this.entries.push({ level: "warn", message, metadata });
+  }
+
+  public debug(message: string, metadata?: Record<string, unknown>): void {
+    this.entries.push({ level: "debug", message, metadata });
   }
 
   public error(message: string, metadata?: Record<string, unknown>): void {

--- a/tests/logger/logger-levels.test.ts
+++ b/tests/logger/logger-levels.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { ConsoleRuntimeLogger, InMemoryRuntimeLogger } from '../../src/logger/runtime-logger.js';
+
+describe('RuntimeLogger warn and debug levels', () => {
+  it('InMemoryRuntimeLogger records warn entries', () => {
+    const logger = new InMemoryRuntimeLogger();
+    logger.warn('test warning', { key: 'value' });
+
+    expect(logger.entries).toHaveLength(1);
+    expect(logger.entries[0].level).toBe('warn');
+    expect(logger.entries[0].message).toBe('test warning');
+    expect(logger.entries[0].metadata).toEqual({ key: 'value' });
+  });
+
+  it('InMemoryRuntimeLogger records debug entries', () => {
+    const logger = new InMemoryRuntimeLogger();
+    logger.debug('test debug', { trace: true });
+
+    expect(logger.entries).toHaveLength(1);
+    expect(logger.entries[0].level).toBe('debug');
+    expect(logger.entries[0].message).toBe('test debug');
+    expect(logger.entries[0].metadata).toEqual({ trace: true });
+  });
+
+  it('ConsoleRuntimeLogger has warn and debug methods', () => {
+    const logger = new ConsoleRuntimeLogger();
+    expect(typeof logger.warn).toBe('function');
+    expect(typeof logger.debug).toBe('function');
+    // Should not throw
+    logger.warn('console warn test');
+    logger.debug('console debug test');
+  });
+
+  it('existing info and error levels still work', () => {
+    const logger = new InMemoryRuntimeLogger();
+    logger.info('info msg');
+    logger.error('error msg');
+
+    expect(logger.entries).toHaveLength(2);
+    expect(logger.entries[0].level).toBe('info');
+    expect(logger.entries[1].level).toBe('error');
+  });
+});


### PR DESCRIPTION
## Summary
Extends the `RuntimeLogger` interface with `warn()` and `debug()` methods, enabling dedicated channels for warnings (e.g. unconfigured provider usage, capacity pressure) and low-level dispatch tracing.

## Changes
- Extended `RuntimeLogger` interface in `src/logger/runtime-logger.ts` with `warn` and `debug` method signatures
- Updated `ConsoleRuntimeLogger` to delegate to `console.warn` and `console.debug`
- Updated `InMemoryRuntimeLogger` to record entries with `'warn'` and `'debug'` level tags
- Existing `info`/`error` call sites remain unchanged (backward compatible)
- Added 4 tests in `tests/logger/logger-levels.test.ts`:
  - InMemoryRuntimeLogger records warn entries correctly
  - InMemoryRuntimeLogger records debug entries correctly
  - ConsoleRuntimeLogger has warn and debug methods (no-throw verification)
  - Existing info/error levels still work (backward compatibility)

## Testing
All 10 tests pass (4 test files). TypeScript compiles clean.

Closes #132