### PR TITLE
feat: add toJSON serialization to RuntimeError (Closes #150)

### DIFF
--- a/src/errors/runtime-errors.ts
+++ b/src/errors/runtime-errors.ts
@@ -20,4 +20,14 @@ export class RuntimeError extends Error {
     this.code = code;
     this.details = details;
   }
+
+  public toJSON(): Record<string, unknown> {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      details: this.details,
+      stack: this.stack,
+    };
+  }
 }

--- a/tests/errors/tojson.test.ts
+++ b/tests/errors/tojson.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { RuntimeError } from '../../src/errors/runtime-errors.js';
+
+describe('RuntimeError.toJSON', () => {
+  it('serializes code and details via JSON.stringify', () => {
+    const error = new RuntimeError('TOOL_NOT_FOUND', 'Tool missing', { toolName: 'foo' });
+    const json = JSON.parse(JSON.stringify(error));
+
+    expect(json.name).toBe('RuntimeError');
+    expect(json.code).toBe('TOOL_NOT_FOUND');
+    expect(json.message).toBe('Tool missing');
+    expect(json.details).toEqual({ toolName: 'foo' });
+    expect(json.stack).toBeDefined();
+    expect(typeof json.stack).toBe('string');
+  });
+
+  it('includes stack trace in toJSON output', () => {
+    const error = new RuntimeError('EXECUTION_FAILED', 'boom');
+    const json = error.toJSON();
+
+    expect(json.stack).toBeDefined();
+    expect(typeof json.stack).toBe('string');
+    expect(json.stack).toContain('RuntimeError');
+  });
+
+  it('handles undefined details gracefully', () => {
+    const error = new RuntimeError('INVALID_TASK', 'bad task');
+    const json = JSON.parse(JSON.stringify(error));
+
+    expect(json.details).toBeUndefined();
+    expect(json.code).toBe('INVALID_TASK');
+    expect(json.message).toBe('bad task');
+  });
+
+  it('preserves all fields through round-trip serialization', () => {
+    const original = new RuntimeError('RUNTIME_NOT_STARTED', 'not started', { runtimeId: 'r1' });
+    const serialized = JSON.stringify(original);
+    const deserialized = JSON.parse(serialized);
+
+    expect(deserialized.name).toBe(original.name);
+    expect(deserialized.code).toBe(original.code);
+    expect(deserialized.message).toBe(original.message);
+    expect(deserialized.details).toEqual(original.details);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a `toJSON()` method to `RuntimeError` that returns `{ name, code, message, details, stack }`, ensuring all error fields survive `JSON.stringify` serialization for logs and API responses.

Without this, only `message` is enumerable by default and `code`/`details` are silently dropped during serialization.

## Changes
- Added `toJSON(): Record<string, unknown>` to `RuntimeError` in `src/errors/runtime-errors.ts`
- Returns `name`, `code`, `message`, `details`, and `stack` fields
- Added 4 tests in `tests/errors/tojson.test.ts`:
  - Verifies `JSON.stringify` round-trip preserves code and details
  - Confirms stack trace is included in output
  - Handles undefined details gracefully
  - Full field fidelity through serialization/deserialization

## Testing
All 10 tests pass (4 test files). TypeScript compiles clean.

Closes #150