### PR TITLE
feat: add shutdown method to AgentRuntime (Closes #135)

### DIFF
--- a/src/runtime/agent-runtime.ts
+++ b/src/runtime/agent-runtime.ts
@@ -43,6 +43,24 @@ export class AgentRuntime {
     });
   }
 
+  public async stop(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+
+    this.started = false;
+    this.dependencies.logger.info("Runtime stopped.", {
+      runtimeId: this.runtimeId
+    });
+    this.dependencies.eventBus.emit({
+      name: "runtime.stopped",
+      payload: {
+        runtimeId: this.runtimeId,
+        occurredAt: new Date().toISOString()
+      }
+    });
+  }
+
   public async executeTask<TPayload, TResult>(
     task: RuntimeTask<TPayload>
   ): Promise<TaskExecutionResult<TResult>> {

--- a/tests/runtime/shutdown.test.ts
+++ b/tests/runtime/shutdown.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AgentRuntime } from '../../src/runtime/agent-runtime.js';
+import { RuntimeError } from '../../src/errors/runtime-errors.js';
+
+describe('AgentRuntime.stop()', () => {
+  function makeRuntime() {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    };
+    const events: any[] = [];
+    const eventBus = {
+      emit: vi.fn((e: any) => events.push(e)),
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+
+    const runtime = new AgentRuntime({
+      runtimeId: 'test-shutdown',
+      logger: logger as any,
+      eventBus: eventBus as any,
+      tools: [],
+      modelProvider: { generate: vi.fn() } as any,
+    });
+
+    return { runtime, logger, events };
+  }
+
+  it('emits runtime.stopped event and logs stop', async () => {
+    const { runtime, logger, events } = makeRuntime();
+    await runtime.start();
+    await runtime.stop();
+
+    const stoppedEvent = events.find((e) => e.name === 'runtime.stopped');
+    expect(stoppedEvent).toBeDefined();
+    expect(stoppedEvent.payload.runtimeId).toBe('test-shutdown');
+    expect(stoppedEvent.payload.occurredAt).toBeDefined();
+
+    const stopLog = logger.info.mock.calls.find(
+      (call: any[]) => typeof call[0] === 'string' && call[0].includes('stopped')
+    );
+    expect(stopLog).toBeDefined();
+  });
+
+  it('is idempotent - calling stop twice does not emit twice', async () => {
+    const { runtime, events } = makeRuntime();
+    await runtime.start();
+    await runtime.stop();
+    await runtime.stop();
+
+    const stoppedEvents = events.filter((e) => e.name === 'runtime.stopped');
+    expect(stoppedEvents).toHaveLength(1);
+  });
+
+  it('rejects executeTask after stop with RUNTIME_NOT_STARTED', async () => {
+    const { runtime } = makeRuntime();
+    runtime.registerTool({
+      name: 'echo',
+      description: 'Echo tool',
+      inputSchema: { type: 'object', properties: {} },
+      execute: vi.fn(async () => ({ echoed: true })),
+    });
+
+    await runtime.start();
+    await runtime.stop();
+
+    await expect(
+      runtime.executeTask({
+        taskId: 'task-after-stop',
+        agentId: 'agent-1',
+        toolName: 'echo',
+        input: 'test',
+        payload: {},
+      })
+    ).rejects.toThrow(RuntimeError);
+
+    try {
+      await runtime.executeTask({
+        taskId: 'task-after-stop-2',
+        agentId: 'agent-1',
+        toolName: 'echo',
+        input: 'test',
+        payload: {},
+      });
+    } catch (error: any) {
+      expect(error.code).toBe('RUNTIME_NOT_STARTED');
+    }
+  });
+
+  it('stop without start is a no-op', async () => {
+    const { runtime, events } = makeRuntime();
+    await runtime.stop();
+    const stoppedEvents = events.filter((e) => e.name === 'runtime.stopped');
+    expect(stoppedEvents).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Adds an async `stop()` method to `AgentRuntime` that marks the runtime as stopped, emits a `runtime.stopped` lifecycle event, and logs the shutdown. The method is idempotent (no-op if already stopped), and subsequent `executeTask` calls correctly reject with `RUNTIME_NOT_STARTED` via the existing guard.

## Changes
- Added `stop(): Promise<void>` to `AgentRuntime` in `src/runtime/agent-runtime.ts`
- Emits `runtime.stopped` event with `runtimeId` and `occurredAt`
- Logs "Runtime stopped." via logger
- Idempotent: calling stop() when not started is a no-op
- Existing `assertRuntimeStarted` guard ensures post-stop task execution rejects

## Testing
Added 4 tests in `tests/runtime/shutdown.test.ts`:
- Verifies `runtime.stopped` event emission and log output
- Confirms idempotency (double stop emits only once)
- Validates `executeTask` after stop rejects with `RUNTIME_NOT_STARTED`
- Confirms stop without start is a safe no-op

All 10 tests pass (4 test files). TypeScript compiles clean.

Closes #135