### PR TITLE
feat: add max-listener guard to RuntimeEventBus (Closes #138)

### DIFF
--- a/src/events/runtime-events.ts
+++ b/src/events/runtime-events.ts
@@ -32,17 +32,36 @@ export type RuntimeEventListener<TName extends RuntimeEventName> = (
   event: RuntimeEvent<TName>
 ) => void;
 
+const DEFAULT_MAX_LISTENERS = 100;
+
 export class RuntimeEventBus {
   private readonly listeners = new Map<
     RuntimeEventName,
     Set<RuntimeEventListener<RuntimeEventName>>
   >();
+  private readonly maxListeners: number;
+
+  public constructor(options?: { maxListeners?: number }) {
+    this.maxListeners = options?.maxListeners ?? DEFAULT_MAX_LISTENERS;
+  }
+
+  public listenerCount(name: RuntimeEventName): number {
+    return this.listeners.get(name)?.size ?? 0;
+  }
 
   public on<TName extends RuntimeEventName>(
     name: TName,
     listener: RuntimeEventListener<TName>
   ): () => void {
     const existing = this.listeners.get(name) ?? new Set();
+
+    if (existing.size >= this.maxListeners) {
+      console.warn(
+        `RuntimeEventBus: max listener count (${this.maxListeners}) exceeded for event "${name}". ` +
+        `This may indicate a memory leak from unsubscribed listeners.`
+      );
+    }
+
     existing.add(listener as RuntimeEventListener<RuntimeEventName>);
     this.listeners.set(name, existing);
 

--- a/tests/events/max-listener-guard.test.ts
+++ b/tests/events/max-listener-guard.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RuntimeEventBus } from '../../src/events/runtime-events.js';
+
+describe('RuntimeEventBus max-listener guard', () => {
+  it('listenerCount returns 0 for unknown events', () => {
+    const bus = new RuntimeEventBus();
+    expect(bus.listenerCount('runtime.started')).toBe(0);
+  });
+
+  it('listenerCount reflects registered listeners', () => {
+    const bus = new RuntimeEventBus();
+    bus.on('runtime.started', () => {});
+    bus.on('runtime.started', () => {});
+    expect(bus.listenerCount('runtime.started')).toBe(2);
+  });
+
+  it('listenerCount decreases after unsubscribe', () => {
+    const bus = new RuntimeEventBus();
+    const unsub = bus.on('runtime.started', () => {});
+    expect(bus.listenerCount('runtime.started')).toBe(1);
+    unsub();
+    expect(bus.listenerCount('runtime.started')).toBe(0);
+  });
+
+  it('warns when max listeners exceeded', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bus = new RuntimeEventBus({ maxListeners: 3 });
+
+    bus.on('runtime.started', () => {});
+    bus.on('runtime.started', () => {});
+    bus.on('runtime.started', () => {});
+    // 4th listener should trigger warning
+    bus.on('runtime.started', () => {});
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('max listener count (3) exceeded');
+    expect(warnSpy.mock.calls[0][0]).toContain('runtime.started');
+
+    warnSpy.mockRestore();
+  });
+
+  it('does not warn below the limit', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bus = new RuntimeEventBus({ maxListeners: 5 });
+
+    for (let i = 0; i < 5; i++) {
+      bus.on('runtime.started', () => {});
+    }
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('uses default max of 100 when no option provided', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bus = new RuntimeEventBus();
+
+    for (let i = 0; i < 100; i++) {
+      bus.on('runtime.started', () => {});
+    }
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // 101st should warn
+    bus.on('runtime.started', () => {});
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('max listener count (100) exceeded');
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Adds a configurable `maxListeners` option (default 100) to `RuntimeEventBus` that warns via `console.warn` when exceeded, preventing silent memory leaks from unsubscribed listeners. Also exposes a `listenerCount(name)` getter for observability.

## Changes
- Added `DEFAULT_MAX_LISTENERS = 100` constant
- Added optional `maxListeners` constructor parameter to `RuntimeEventBus`
- Added `listenerCount(name): number` public method
- `on()` now checks listener count before adding and emits `console.warn` if limit exceeded
- Warning message includes event name and configured limit for debugging

## Testing
Added 6 tests in `tests/events/max-listener-guard.test.ts`:
- `listenerCount` returns 0 for unknown events
- `listenerCount` reflects registered listeners accurately
- `listenerCount` decreases after unsubscribe
- Warning emitted when max listeners exceeded
- No warning below the limit
- Default max of 100 applied when no option provided

All 12 tests pass (4 test files). TypeScript compiles clean.

Closes #138