### PR TITLE
feat: warn when UnconfiguredModelProvider is used (Closes #143)

### DIFF
--- a/src/providers/model-provider.ts
+++ b/src/providers/model-provider.ts
@@ -16,10 +16,21 @@ export interface ModelProvider {
 export class UnconfiguredModelProvider implements ModelProvider {
   public readonly name = "unconfigured";
 
-  public async generate(): Promise<ModelResponse> {
+  public async generate(prompt: ModelPrompt): Promise<ModelResponse> {
+    console.warn(
+      "UnconfiguredModelProvider: no model provider is configured. " +
+      "generate() was called but will return placeholder text. " +
+      "Configure a real ModelProvider to enable AI-powered task execution."
+    );
+
     return {
       outputText:
-        "No model provider is configured. Contributors can implement one behind the ModelProvider interface."
+        "No model provider is configured. Contributors can implement one behind the ModelProvider interface.",
+      metadata: {
+        warning: "unconfigured_provider",
+        instructionsLength: prompt.instructions?.length ?? 0,
+        inputLength: prompt.input?.length ?? 0
+      }
     };
   }
 }

--- a/tests/providers/unconfigured-warn.test.ts
+++ b/tests/providers/unconfigured-warn.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { UnconfiguredModelProvider } from '../../src/providers/model-provider.js';
+
+describe('UnconfiguredModelProvider warning', () => {
+  it('emits console.warn on generate()', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = new UnconfiguredModelProvider();
+
+    await provider.generate({ instructions: 'test', input: 'hello' });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('UnconfiguredModelProvider');
+    expect(warnSpy.mock.calls[0][0]).toContain('no model provider is configured');
+
+    warnSpy.mockRestore();
+  });
+
+  it('returns placeholder outputText with warning metadata', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = new UnconfiguredModelProvider();
+
+    const result = await provider.generate({ instructions: 'do something', input: 'data' });
+
+    expect(result.outputText).toContain('No model provider is configured');
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata!.warning).toBe('unconfigured_provider');
+    expect(result.metadata!.instructionsLength).toBe(12);
+    expect(result.metadata!.inputLength).toBe(4);
+
+    warnSpy.mockRestore();
+  });
+
+  it('handles empty prompt gracefully', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = new UnconfiguredModelProvider();
+
+    const result = await provider.generate({ instructions: '', input: '' });
+
+    expect(result.metadata!.instructionsLength).toBe(0);
+    expect(result.metadata!.inputLength).toBe(0);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Adds a `console.warn` to `UnconfiguredModelProvider.generate()` so deployments that accidentally use the placeholder provider are immediately visible in logs instead of silently returning stub text.

Also adds `metadata.warning='unconfigured_provider'` and prompt length stats to the response for programmatic detection by downstream consumers.

## Changes
- `UnconfiguredModelProvider.generate()` now emits `console.warn` with clear misconfiguration message
- Response includes `metadata` object with `warning`, `instructionsLength`, and `inputLength` fields
- Configured providers are completely unaffected

## Testing
Added 3 tests in `tests/providers/unconfigured-warn.test.ts`:
- Verifies `console.warn` is emitted on every `generate()` call
- Verifies placeholder outputText and warning metadata are present
- Verifies graceful handling of empty prompts

All 9 tests pass (4 test files). TypeScript compiles clean.

Closes #143