### PR TITLE
feat: add redaction support for sensitive log metadata (Closes #144)

### DIFF
--- a/src/logger/runtime-logger.ts
+++ b/src/logger/runtime-logger.ts
@@ -3,13 +3,45 @@ export interface RuntimeLogger {
   error(message: string, metadata?: Record<string, unknown>): void;
 }
 
+const DEFAULT_REDACT_PATTERN = /secret|token|password|apiKey|api_key|authorization/i;
+
+export interface ConsoleRuntimeLoggerOptions {
+  /** Regex pattern matching metadata keys to redact. Default matches secret/token/password/apiKey/authorization. */
+  redactKeys?: RegExp;
+}
+
+function redactMetadata(
+  metadata: Record<string, unknown>,
+  pattern: RegExp
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (pattern.test(key)) {
+      result[key] = "[REDACTED]";
+    } else if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      result[key] = redactMetadata(value as Record<string, unknown>, pattern);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 export class ConsoleRuntimeLogger implements RuntimeLogger {
+  private readonly redactPattern: RegExp;
+
+  public constructor(options?: ConsoleRuntimeLoggerOptions) {
+    this.redactPattern = options?.redactKeys ?? DEFAULT_REDACT_PATTERN;
+  }
+
   public info(message: string, metadata?: Record<string, unknown>): void {
-    console.info(message, metadata ?? {});
+    const safeMeta = metadata ? redactMetadata(metadata, this.redactPattern) : {};
+    console.info(message, safeMeta);
   }
 
   public error(message: string, metadata?: Record<string, unknown>): void {
-    console.error(message, metadata ?? {});
+    const safeMeta = metadata ? redactMetadata(metadata, this.redactPattern) : {};
+    console.error(message, safeMeta);
   }
 }
 

--- a/tests/logger/redaction.test.ts
+++ b/tests/logger/redaction.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ConsoleRuntimeLogger } from '../../src/logger/runtime-logger.js';
+
+describe('ConsoleRuntimeLogger redaction', () => {
+  it('redacts default sensitive keys (secret, token, password, apiKey, authorization)', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const logger = new ConsoleRuntimeLogger();
+
+    logger.info('test', {
+      userId: 'u1',
+      apiToken: 'abc-123',
+      password: 'hunter2',
+      apiKey: 'sk-live-xxx',
+      authorization: 'Bearer xyz',
+      secretKey: 'my-secret',
+      normalField: 'visible'
+    });
+
+    const loggedMeta = infoSpy.mock.calls[0][1];
+    expect(loggedMeta.userId).toBe('u1');
+    expect(loggedMeta.normalField).toBe('visible');
+    expect(loggedMeta.apiToken).toBe('[REDACTED]');
+    expect(loggedMeta.password).toBe('[REDACTED]');
+    expect(loggedMeta.apiKey).toBe('[REDACTED]');
+    expect(loggedMeta.authorization).toBe('[REDACTED]');
+    expect(loggedMeta.secretKey).toBe('[REDACTED]');
+
+    infoSpy.mockRestore();
+  });
+
+  it('accepts custom redactKeys pattern', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const logger = new ConsoleRuntimeLogger({ redactKeys: /^ssn$/i });
+
+    logger.info('test', { ssn: '123-45-6789', name: 'Alice', token: 'visible-token' });
+
+    const loggedMeta = infoSpy.mock.calls[0][1];
+    expect(loggedMeta.ssn).toBe('[REDACTED]');
+    expect(loggedMeta.name).toBe('Alice');
+    expect(loggedMeta.token).toBe('visible-token');
+
+    infoSpy.mockRestore();
+  });
+
+  it('redacts nested objects recursively', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const logger = new ConsoleRuntimeLogger();
+
+    logger.info('nested test', {
+      user: {
+        name: 'Bob',
+        credentials: {
+          password: 'secret',
+          token: 'tok-123'
+        }
+      },
+      safe: 'value'
+    });
+
+    const loggedMeta = infoSpy.mock.calls[0][1];
+    expect(loggedMeta.user.name).toBe('Bob');
+    expect(loggedMeta.user.credentials.password).toBe('[REDACTED]');
+    expect(loggedMeta.user.credentials.token).toBe('[REDACTED]');
+    expect(loggedMeta.safe).toBe('value');
+
+    infoSpy.mockRestore();
+  });
+
+  it('does not redact arrays', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const logger = new ConsoleRuntimeLogger();
+
+    logger.info('array test', { tags: ['a', 'b'], secret: 'hidden' });
+
+    const loggedMeta = infoSpy.mock.calls[0][1];
+    expect(loggedMeta.tags).toEqual(['a', 'b']);
+    expect(loggedMeta.secret).toBe('[REDACTED]');
+
+    infoSpy.mockRestore();
+  });
+
+  it('handles undefined metadata gracefully', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const logger = new ConsoleRuntimeLogger();
+
+    expect(() => logger.info('no meta')).not.toThrow();
+    expect(infoSpy.mock.calls[0][1]).toEqual({});
+
+    infoSpy.mockRestore();
+  });
+
+  it('applies redaction to error() as well', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const logger = new ConsoleRuntimeLogger();
+
+    logger.error('fail', { apiKey: 'leaked', detail: 'oops' });
+
+    const loggedMeta = errorSpy.mock.calls[0][1];
+    expect(loggedMeta.apiKey).toBe('[REDACTED]');
+    expect(loggedMeta.detail).toBe('oops');
+
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Adds configurable `redactKeys` option to `ConsoleRuntimeLogger` that masks metadata keys matching a regex pattern, preventing secrets from leaking into logs.

Default pattern matches `secret|token|password|apiKey|api_key|authorization` (case-insensitive). Redaction applies recursively to nested objects but preserves arrays. Both `info()` and `error()` are covered.

## Changes
- Added `ConsoleRuntimeLoggerOptions` interface with optional `redactKeys` RegExp
- Added `redactMetadata()` helper that recursively masks matching keys with `[REDACTED]`
- Constructor accepts options; defaults to comprehensive sensitive-key pattern
- Arrays are preserved as-is; only plain objects are recursed into

## Testing
Added 6 tests in `tests/logger/redaction.test.ts`:
- Default sensitive key redaction (secret, token, password, apiKey, authorization)
- Custom redactKeys pattern
- Recursive nested object redaction
- Array preservation
- Undefined metadata handling
- error() coverage

All 12 tests pass (4 test files). TypeScript compiles clean.

Closes #144