### PR TITLE
test: add unit tests for UnconfiguredModelProvider placeholder contract (Issue #116)

### DIFF
--- a/tests/providers/model-provider.test.ts
+++ b/tests/providers/model-provider.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { UnconfiguredModelProvider } from "../../src/providers/model-provider.js";
+
+describe("UnconfiguredModelProvider", () => {
+  const provider = new UnconfiguredModelProvider();
+
+  it("has name set to 'unconfigured'", () => {
+    expect(provider.name).toBe("unconfigured");
+  });
+
+  it("returns stable outputText regardless of prompt input", async () => {
+    const response = await provider.generate({
+      instructions: "ignored-instructions",
+      input: "ignored-input",
+    });
+
+    expect(response.outputText).toBe(
+      "No model provider is configured. Contributors can implement one behind the ModelProvider interface."
+    );
+  });
+
+  it("returns same response shape for empty prompt", async () => {
+    const response = await provider.generate({ instructions: "", input: "" });
+
+    expect(response).toHaveProperty("outputText");
+    expect(typeof response.outputText).toBe("string");
+    expect(response.outputText.length).toBeGreaterThan(0);
+  });
+
+  it("ignores prompt arguments completely", async () => {
+    const r1 = await provider.generate({ instructions: "a", input: "b" });
+    const r2 = await provider.generate({ instructions: "completely-different", input: "also-different" });
+
+    expect(r1.outputText).toBe(r2.outputText);
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests verifying the `UnconfiguredModelProvider` placeholder contract in `src/providers/model-provider.ts`.

## Tests Added
- ✅ `name` property equals `"unconfigured"`
- ✅ Returns stable `outputText` regardless of prompt input
- ✅ Response shape consistent for empty prompts
- ✅ Prompt arguments completely ignored across different inputs

## Verification
All 4 tests pass locally via `npx vitest run tests/providers/model-provider.test.ts`.

Closes #116