### PR TITLE
test: assert DUPLICATE_TOOL error code and details.toolName (Issue #124)

### DIFF
--- a/tests/tool-registry.test.ts
+++ b/tests/tool-registry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { RuntimeError, ToolRegistry } from "../src/index.js";
 
 describe("ToolRegistry", () => {
-  it("prevents duplicate tool names", () => {
+  it("prevents duplicate tool names with correct error code and details", () => {
     const registry = new ToolRegistry();
     const tool = {
       name: "echo",
@@ -14,7 +14,22 @@ describe("ToolRegistry", () => {
 
     registry.register(tool);
 
-    expect(() => registry.register(tool)).toThrowError(RuntimeError);
-    expect(() => registry.register(tool)).toThrow(/already registered/);
+    try {
+      registry.register(tool);
+      expect.fail("should have thrown");
+    } catch (e) {
+      const err = e as RuntimeError;
+      expect(err).toBeInstanceOf(RuntimeError);
+      expect(err.code).toBe("DUPLICATE_TOOL");
+      expect(err.details?.toolName).toBe("echo");
+      expect(err.message).toMatch(/already registered/);
+    }
+  });
+
+  it("allows registering different tools with distinct names", () => {
+    const registry = new ToolRegistry();
+    registry.register({ name: "a", description: "A", execute: () => "a" });
+    registry.register({ name: "b", description: "B", execute: () => "b" });
+    expect(registry.list()).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
Strengthens the existing duplicate tool registration test to assert the specific `DUPLICATE_TOOL` error code and `details.toolName` field, preventing regression on error metadata.

## Tests Added
- ✅ `code === "DUPLICATE_TOOL"` asserted
- ✅ `details.toolName === "echo"` asserted
- ✅ Existing message assertion retained
- ✅ Distinct tool names register successfully

## Verification
All 2 tests pass locally via `npx vitest run tests/tool-registry.test.ts`.

Closes #124