### PR TITLE
test: add unit tests for InMemoryRuntimeStateStore put/get round trips (Issue #109)

### DIFF
--- a/tests/state/runtime-state-store.test.ts
+++ b/tests/state/runtime-state-store.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { InMemoryRuntimeStateStore } from "../../src/state/runtime-state.js";
+
+describe("InMemoryRuntimeStateStore put/get round trips", () => {
+  it("stores and retrieves a string value", async () => {
+    const store = new InMemoryRuntimeStateStore();
+    await store.put("key1", "value1");
+    const result = await store.get<string>("key1");
+    expect(result).toBe("value1");
+  });
+
+  it("stores and retrieves an object value", async () => {
+    const store = new InMemoryRuntimeStateStore();
+    const obj = { taskId: "t1", status: "running" };
+    await store.put("taskState", obj);
+    const result = await store.get<typeof obj>("taskState");
+    expect(result).toEqual(obj);
+  });
+
+  it("returns undefined for non-existent keys", async () => {
+    const store = new InMemoryRuntimeStateStore();
+    const result = await store.get("missing");
+    expect(result).toBeUndefined();
+  });
+
+  it("overwrites existing values on subsequent puts", async () => {
+    const store = new InMemoryRuntimeStateStore();
+    await store.put("counter", 1);
+    await store.put("counter", 2);
+    const result = await store.get<number>("counter");
+    expect(result).toBe(2);
+  });
+
+  it("handles null and zero as valid stored values", async () => {
+    const store = new InMemoryRuntimeStateStore();
+    await store.put("nullVal", null);
+    await store.put("zeroVal", 0);
+    expect(await store.get("nullVal")).toBeNull();
+    expect(await store.get("zeroVal")).toBe(0);
+  });
+
+  it("isolates keys across multiple put operations", async () => {
+    const store = new InMemoryRuntimeStateStore();
+    await store.put("a", "alpha");
+    await store.put("b", "beta");
+    await store.put("c", "gamma");
+    expect(await store.get<string>("a")).toBe("alpha");
+    expect(await store.get<string>("b")).toBe("beta");
+    expect(await store.get<string>("c")).toBe("gamma");
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests verifying `InMemoryRuntimeStateStore` put/get semantics including type preservation, overwrite behavior, null/zero handling, and key isolation.

## Tests Added
- ✅ String and object values stored and retrieved correctly
- ✅ Undefined returned for non-existent keys
- ✅ Subsequent puts overwrite existing values
- ✅ Null and zero preserved as valid stored values
- ✅ Multiple keys isolated from each other

## Verification
All 6 tests pass locally via `npx vitest run tests/state/runtime-state-store.test.ts`.

Closes #109