### PR TITLE
test: add unit tests for ActionExecutor tool dispatch and payload passthrough (Issue #115)

### DIFF
--- a/tests/actions/action-executor.test.ts
+++ b/tests/actions/action-executor.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { ActionExecutor } from "../../src/actions/action-executor.js";
+import { ToolRegistry } from "../../src/tools/tool-registry.js";
+
+describe("ActionExecutor tool dispatch and payload passthrough (Issue #115)", () => {
+  it("dispatches to the correct registered tool by name", async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "add",
+      description: "Adds two numbers",
+      execute: ({ payload }) => ({ sum: (payload as any).a + (payload as any).b }),
+    });
+    registry.register({
+      name: "multiply",
+      description: "Multiplies two numbers",
+      execute: ({ payload }) => ({ product: (payload as any).a * (payload as any).b }),
+    });
+
+    const executor = new ActionExecutor(registry);
+    const ctx = {} as any;
+
+    const addResult = await executor.execute("add", { a: 3, b: 4 }, ctx);
+    expect(addResult).toEqual({ sum: 7 });
+
+    const mulResult = await executor.execute("multiply", { a: 3, b: 4 }, ctx);
+    expect(mulResult).toEqual({ product: 12 });
+  });
+
+  it("passes payload through to tool execute without modification", async () => {
+    const registry = new ToolRegistry();
+    let receivedPayload: unknown = null;
+    registry.register({
+      name: "capture",
+      description: "Captures payload for inspection",
+      execute: ({ payload }) => {
+        receivedPayload = payload;
+        return { ok: true };
+      },
+    });
+
+    const executor = new ActionExecutor(registry);
+    const complexPayload = { nested: { arr: [1, 2, 3], flag: true }, label: "test" };
+    await executor.execute("capture", complexPayload, {} as any);
+
+    expect(receivedPayload).toBe(complexPayload);
+  });
+
+  it("passes context through to tool execute", async () => {
+    const registry = new ToolRegistry();
+    let receivedContext: any = null;
+    registry.register({
+      name: "ctxCapture",
+      description: "Captures context for inspection",
+      execute: ({ context }) => {
+        receivedContext = context;
+        return { ok: true };
+      },
+    });
+
+    const executor = new ActionExecutor(registry);
+    const mockContext = { runtimeId: "r1", taskId: "t1" } as any;
+    await executor.execute("ctxCapture", {}, mockContext);
+
+    expect(receivedContext).toBe(mockContext);
+  });
+
+  it("throws TOOL_NOT_FOUND for unregistered tool names", async () => {
+    const registry = new ToolRegistry();
+    const executor = new ActionExecutor(registry);
+
+    await expect(
+      executor.execute("nonexistent", {}, {} as any)
+    ).rejects.toThrow(/not registered/);
+  });
+
+  it("returns async tool results correctly", async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "asyncTool",
+      description: "Returns a promise",
+      execute: async ({ payload }) => {
+        return { value: (payload as any).x * 10 };
+      },
+    });
+
+    const executor = new ActionExecutor(registry);
+    const result = await executor.execute("asyncTool", { x: 5 }, {} as any);
+    expect(result).toEqual({ value: 50 });
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests verifying `ActionExecutor` correctly dispatches to registered tools by name, passes payload and context through without modification, handles async tools, and throws on unregistered tool names.

## Tests Added
- ✅ Dispatches to correct registered tool by name
- ✅ Payload passed through to tool execute without modification
- ✅ Context passed through to tool execute
- ✅ Throws TOOL_NOT_FOUND for unregistered tool names
- ✅ Returns async tool results correctly

## Verification
All 5 tests pass locally via `npx vitest run tests/actions/action-executor.test.ts`.

Closes #115