### PR TITLE
test: add property-based tests for memory store append/list invariants (Closes #148)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.27.0",
         "eslint-config-prettier": "^10.1.5",
+        "fast-check": "^4.9.0",
         "globals": "^16.1.0",
         "prettier": "^3.5.3",
         "typescript": "^5.8.3",
@@ -1229,7 +1230,6 @@
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1279,7 +1279,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -1672,7 +1671,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2006,7 +2004,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2189,6 +2186,29 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2884,7 +2904,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2956,6 +2975,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3396,7 +3432,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3550,7 +3585,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.27.0",
     "eslint-config-prettier": "^10.1.5",
+    "fast-check": "^4.9.0",
     "globals": "^16.1.0",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",

--- a/tests/memory/in-memory-memory-store.property.test.ts
+++ b/tests/memory/in-memory-memory-store.property.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { InMemoryMemoryStore, MemoryEntry } from '../../src/memory/memory-store';
+
+describe('InMemoryMemoryStore property-based tests', () => {
+  const agentIdArb = fc.string({ minLength: 1, maxLength: 20 });
+  const taskIdArb = fc.string({ minLength: 1, maxLength: 20 });
+  const inputArb = fc.string();
+  const outputArb = fc.anything();
+  const recordedAtArb = fc.date().map((d) => d.toISOString());
+
+  const entryArb: fc.Arbitrary<MemoryEntry> = fc.record({
+    agentId: agentIdArb,
+    taskId: taskIdArb,
+    input: inputArb,
+    output: outputArb,
+    recordedAt: recordedAtArb,
+  });
+
+  it('listByAgent returns exactly entries for that agent in append order', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.array(entryArb, { minLength: 0, maxLength: 100 }), async (entries) => {
+        const store = new InMemoryMemoryStore();
+        for (const entry of entries) {
+          await store.append(entry);
+        }
+
+        const uniqueAgents = [...new Set(entries.map((e) => e.agentId))];
+        for (const agentId of uniqueAgents) {
+          const expected = entries.filter((e) => e.agentId === agentId);
+          const actual = await store.listByAgent(agentId);
+          expect(actual).toEqual(expected);
+        }
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  it('append preserves insertion order across mixed agents', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.array(entryArb, { minLength: 1, maxLength: 100 }), async (entries) => {
+        const store = new InMemoryMemoryStore();
+        for (const entry of entries) {
+          await store.append(entry);
+        }
+
+        const uniqueAgents = [...new Set(entries.map((e) => e.agentId))];
+        for (const agentId of uniqueAgents) {
+          const filtered = entries.filter((e) => e.agentId === agentId);
+          const listed = await store.listByAgent(agentId);
+          expect(listed.map((e) => e.taskId)).toEqual(filtered.map((e) => e.taskId));
+        }
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  it('listByAgent returns empty array for unknown agent after arbitrary appends', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.array(entryArb, { maxLength: 50 }), agentIdArb, async (entries, unknownAgent) => {
+        const store = new InMemoryMemoryStore();
+        for (const entry of entries) {
+          await store.append(entry);
+        }
+
+        const wasUsed = entries.some((e) => e.agentId === unknownAgent);
+        if (!wasUsed) {
+          const result = await store.listByAgent(unknownAgent);
+          expect(result).toEqual([]);
+        }
+      }),
+      { numRuns: 50 }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds property-based tests for `InMemoryMemoryStore` using `fast-check` to verify that `listByAgent` correctly filters entries by agent and preserves append order across arbitrary sequences.

## Changes
- Added `fast-check` as dev dependency
- Created `tests/memory/in-memory-memory-store.property.test.ts` with 3 property tests:
  - `listByAgent` returns exactly matching entries in append order
  - Insertion order preserved across mixed agents
  - Unknown agent returns empty array after arbitrary appends

## Testing
All 3 property tests pass (50 runs each). TypeScript compiles clean.

Closes #148