### PR TITLE
feat(memory): enforce capacity limit and FIFO eviction in InMemoryMemoryStore (Closes #107)

### DIFF
--- a/src/memory/memory-store.ts
+++ b/src/memory/memory-store.ts
@@ -11,14 +11,45 @@ export interface MemoryStore {
   listByAgent(agentId: string): Promise<MemoryEntry[]>;
 }
 
+export interface InMemoryMemoryStoreOptions {
+  /** Maximum number of entries to retain in memory before FIFO eviction. Defaults to 10_000. */
+  maxEntries?: number;
+}
+
+export const DEFAULT_MAX_MEMORY_ENTRIES = 10_000;
+
 export class InMemoryMemoryStore implements MemoryStore {
   private readonly entries: MemoryEntry[] = [];
+  public readonly maxEntries: number;
+
+  public constructor(options?: InMemoryMemoryStoreOptions | number) {
+    if (typeof options === "number") {
+      this.maxEntries = options;
+    } else {
+      this.maxEntries = options?.maxEntries ?? DEFAULT_MAX_MEMORY_ENTRIES;
+    }
+
+    if (this.maxEntries <= 0 || !Number.isFinite(this.maxEntries)) {
+      throw new RangeError("maxEntries must be a positive finite integer");
+    }
+  }
+
+  public get size(): number {
+    return this.entries.length;
+  }
 
   public async append(entry: MemoryEntry): Promise<void> {
+    if (this.entries.length >= this.maxEntries) {
+      this.entries.shift();
+    }
     this.entries.push(entry);
   }
 
   public async listByAgent(agentId: string): Promise<MemoryEntry[]> {
     return this.entries.filter((entry) => entry.agentId === agentId);
+  }
+
+  public async clear(): Promise<void> {
+    this.entries.length = 0;
   }
 }

--- a/tests/memory/memory-store-capacity.test.ts
+++ b/tests/memory/memory-store-capacity.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  InMemoryMemoryStore,
+  DEFAULT_MAX_MEMORY_ENTRIES
+} from "../../src/memory/memory-store.js";
+
+describe("InMemoryMemoryStore Capacity & Eviction Invariants", () => {
+  it("initializes with default maximum capacity of 10,000", () => {
+    const store = new InMemoryMemoryStore();
+    expect(store.maxEntries).toBe(DEFAULT_MAX_MEMORY_ENTRIES);
+    expect(store.size).toBe(0);
+  });
+
+  it("supports explicit numeric and object capacity configuration", () => {
+    const storeObj = new InMemoryMemoryStore({ maxEntries: 25 });
+    expect(storeObj.maxEntries).toBe(25);
+
+    const storeNum = new InMemoryMemoryStore(50);
+    expect(storeNum.maxEntries).toBe(50);
+  });
+
+  it("throws RangeError on non-positive or invalid capacity", () => {
+    expect(() => new InMemoryMemoryStore(0)).toThrow(RangeError);
+    expect(() => new InMemoryMemoryStore(-10)).toThrow(RangeError);
+    expect(() => new InMemoryMemoryStore(NaN)).toThrow(RangeError);
+  });
+
+  it("evicts oldest entries in FIFO order when maxEntries is exceeded", async () => {
+    const store = new InMemoryMemoryStore({ maxEntries: 3 });
+
+    for (let i = 1; i <= 5; i++) {
+      await store.append({
+        agentId: "agent-1",
+        taskId: `task-${i}`,
+        input: `input-${i}`,
+        output: { step: i },
+        recordedAt: new Date().toISOString()
+      });
+    }
+
+    expect(store.size).toBe(3);
+    const records = await store.listByAgent("agent-1");
+    expect(records.map((r) => r.taskId)).toEqual(["task-3", "task-4", "task-5"]);
+  });
+
+  it("maintains agent isolation across eviction cycles", async () => {
+    const store = new InMemoryMemoryStore({ maxEntries: 3 });
+
+    await store.append({ agentId: "agent-A", taskId: "t1", input: "i1", output: 1, recordedAt: "" });
+    await store.append({ agentId: "agent-B", taskId: "t2", input: "i2", output: 2, recordedAt: "" });
+    await store.append({ agentId: "agent-A", taskId: "t3", input: "i3", output: 3, recordedAt: "" });
+    // Capacity reached (3). Appending 4th evicts t1
+    await store.append({ agentId: "agent-B", taskId: "t4", input: "i4", output: 4, recordedAt: "" });
+
+    const aEntries = await store.listByAgent("agent-A");
+    const bEntries = await store.listByAgent("agent-B");
+
+    expect(aEntries.map((e) => e.taskId)).toEqual(["t3"]);
+    expect(bEntries.map((e) => e.taskId)).toEqual(["t2", "t4"]);
+  });
+
+  it("clears all stored memory entries", async () => {
+    const store = new InMemoryMemoryStore({ maxEntries: 10 });
+    await store.append({ agentId: "agent-1", taskId: "t1", input: "i1", output: 1, recordedAt: "" });
+    expect(store.size).toBe(1);
+    await store.clear();
+    expect(store.size).toBe(0);
+    expect(await store.listByAgent("agent-1")).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Summary
Enforces configurable capacity limits and FIFO eviction on `InMemoryMemoryStore` to prevent unbounded memory growth and process leaks in long-running agent runtime sessions.

### Features
- Added `InMemoryMemoryStoreOptions` with `maxEntries` (default: `10_000`).
- Implemented strict FIFO eviction (`entries.shift()`) upon reaching maximum capacity.
- Added `size` getter and `clear()` method for memory store inspection and lifecycle reset.
- Added unit test suite in `tests/memory/memory-store-capacity.test.ts` verifying default limits, custom limits, FIFO order preservation, and agent boundary isolation.

Closes #107