### PR TITLE
feat(logger): add minimum level filtering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,10 @@ export { AgentInstanceManager } from "./agents/agent-instance-manager.js";
 export { ActionExecutor } from "./actions/action-executor.js";
 export { RuntimeError } from "./errors/runtime-errors.js";
 export { RuntimeEventBus } from "./events/runtime-events.js";
-export { InMemoryRuntimeLogger } from "./logger/runtime-logger.js";
+export {
+  ConsoleRuntimeLogger,
+  InMemoryRuntimeLogger
+} from "./logger/runtime-logger.js";
 export { InMemoryMemoryStore } from "./memory/memory-store.js";
 export { UnconfiguredModelProvider } from "./providers/model-provider.js";
 export { InMemoryRuntimeStateStore } from "./state/runtime-state.js";
@@ -22,7 +25,11 @@ export type {
   RuntimeEventMap,
   RuntimeEventName
 } from "./events/runtime-events.js";
-export type { RuntimeLogger } from "./logger/runtime-logger.js";
+export type {
+  ConsoleRuntimeLoggerOptions,
+  RuntimeLogger,
+  RuntimeLogLevel
+} from "./logger/runtime-logger.js";
 export type { MemoryEntry, MemoryStore } from "./memory/memory-store.js";
 export type {
   ModelPrompt,

--- a/src/logger/runtime-logger.ts
+++ b/src/logger/runtime-logger.ts
@@ -3,13 +3,39 @@ export interface RuntimeLogger {
   error(message: string, metadata?: Record<string, unknown>): void;
 }
 
+export type RuntimeLogLevel = "info" | "warn" | "error";
+
+export interface ConsoleRuntimeLoggerOptions {
+  level?: RuntimeLogLevel;
+}
+
+const levelPriority: Record<RuntimeLogLevel, number> = {
+  info: 0,
+  warn: 1,
+  error: 2
+};
+
 export class ConsoleRuntimeLogger implements RuntimeLogger {
+  private readonly minimumLevel: RuntimeLogLevel;
+
+  public constructor(options: ConsoleRuntimeLoggerOptions = {}) {
+    this.minimumLevel = options.level ?? "info";
+  }
+
   public info(message: string, metadata?: Record<string, unknown>): void {
-    console.info(message, metadata ?? {});
+    if (this.shouldLog("info")) {
+      console.info(message, metadata ?? {});
+    }
   }
 
   public error(message: string, metadata?: Record<string, unknown>): void {
-    console.error(message, metadata ?? {});
+    if (this.shouldLog("error")) {
+      console.error(message, metadata ?? {});
+    }
+  }
+
+  private shouldLog(level: "info" | "error"): boolean {
+    return levelPriority[level] >= levelPriority[this.minimumLevel];
   }
 }
 

--- a/tests/runtime-logger.test.ts
+++ b/tests/runtime-logger.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConsoleRuntimeLogger } from "../src/index.js";
+
+describe("ConsoleRuntimeLogger", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs info and error messages by default", () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const logger = new ConsoleRuntimeLogger();
+
+    logger.info("runtime started");
+    logger.error("runtime failed", { taskId: "task-1" });
+
+    expect(info).toHaveBeenCalledWith("runtime started", {});
+    expect(error).toHaveBeenCalledWith("runtime failed", {
+      taskId: "task-1"
+    });
+  });
+
+  it("suppresses info below a warn threshold", () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const logger = new ConsoleRuntimeLogger({ level: "warn" });
+
+    logger.info("verbose message");
+    logger.error("important message");
+
+    expect(info).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith("important message", {});
+  });
+
+  it("allows only errors at the error threshold", () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const logger = new ConsoleRuntimeLogger({ level: "error" });
+
+    logger.info("verbose message");
+    logger.error("error message");
+
+    expect(info).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- add typed info, warn, and error minimum-level options to ConsoleRuntimeLogger
- retain info as the default and suppress messages below the configured threshold
- export the console logger and its option types from the package entry point
- cover default, warn-threshold, and error-threshold behavior

## Validation
- changed files pass Prettier
- npm run lint
- npm run typecheck
- npm test (9 tests)
- npm run build

Note: repository-wide format verification reports pre-existing differences in 33 unrelated files; all changed files pass independently.

Closes #133