### PR TITLE
feat(actions): add wallet-aware action stub for payment prep (Closes #1)

### DIFF
--- a/src/actions/payment-prep-action.ts
+++ b/src/actions/payment-prep-action.ts
@@ -1,0 +1,80 @@
+import { RuntimeError } from "../errors/runtime-errors.js";
+import { assertNonEmptyValue } from "../guards/runtime-guards.js";
+import type { ToolDefinition, ToolInvocation } from "../tools/types.js";
+
+export interface PaymentPrepPayload {
+  walletId: string;
+  amount: string | number;
+  recipientId?: string | undefined;
+  assetCode?: string | undefined;
+  memo?: string | undefined;
+  metadata?: Record<string, unknown> | undefined;
+}
+
+export interface PaymentPrepResult {
+  status: "prepared";
+  walletId: string;
+  amount: string;
+  recipientId?: string | undefined;
+  assetCode: string;
+  memo?: string | undefined;
+  preparedAt: string;
+  transactionStubId: string;
+  isSimulated: true;
+  metadata?: Record<string, unknown> | undefined;
+}
+
+export const PAYMENT_PREP_TOOL_NAME = "wallet.prepare_payment";
+
+export function createPaymentPrepTool(): ToolDefinition<
+  PaymentPrepPayload,
+  PaymentPrepResult
+> {
+  return {
+    name: PAYMENT_PREP_TOOL_NAME,
+    description:
+      "Prepares and validates payment context and transaction stub for AgentLily wallet tasks without performing live Stellar network calls.",
+    execute({
+      payload,
+      context
+    }: ToolInvocation<PaymentPrepPayload>): PaymentPrepResult {
+      assertNonEmptyValue(payload.walletId, "walletId");
+
+      if (
+        payload.amount === undefined ||
+        payload.amount === null ||
+        String(payload.amount).trim().length === 0
+      ) {
+        throw new RuntimeError("INVALID_TASK", "amount must be specified.", {
+          fieldName: "amount"
+        });
+      }
+
+      const amountStr = String(payload.amount);
+      const parsedAmount = Number(amountStr);
+      if (Number.isNaN(parsedAmount) || parsedAmount <= 0) {
+        throw new RuntimeError(
+          "INVALID_TASK",
+          "amount must be a positive number.",
+          { amount: payload.amount }
+        );
+      }
+
+      const preparedAt = context.now || new Date().toISOString();
+      const transactionStubId = `stellar-stub-${context.taskId}-${payload.walletId}`;
+
+      return {
+        status: "prepared",
+        walletId: payload.walletId,
+        amount: amountStr,
+        recipientId: payload.recipientId,
+        assetCode: payload.assetCode ?? "XLM",
+        memo: payload.memo,
+        preparedAt,
+        transactionStubId,
+        isSimulated: true,
+        metadata: payload.metadata
+      };
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,16 @@ export { UnconfiguredModelProvider } from "./providers/model-provider.js";
 export { InMemoryRuntimeStateStore } from "./state/runtime-state.js";
 export { TaskRunner } from "./tasks/task-runner.js";
 export { ToolRegistry } from "./tools/tool-registry.js";
+export {
+  PAYMENT_PREP_TOOL_NAME,
+  createPaymentPrepTool
+} from "./actions/payment-prep-action.js";
 
 export type { AgentInstance } from "./agents/agent-instance-manager.js";
+export type {
+  PaymentPrepPayload,
+  PaymentPrepResult
+} from "./actions/payment-prep-action.js";
 export type { RuntimeErrorCode } from "./errors/runtime-errors.js";
 export type {
   RuntimeEvent,

--- a/tests/agent-runtime.test.ts
+++ b/tests/agent-runtime.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   AgentRuntime,
+  createPaymentPrepTool,
   InMemoryRuntimeLogger,
+  PAYMENT_PREP_TOOL_NAME,
   RuntimeEventBus
 } from "../src/index.js";
+import type { PaymentPrepPayload, PaymentPrepResult } from "../src/index.js";
 
 describe("AgentRuntime", () => {
   it("executes a happy-path task and records memory", async () => {
@@ -122,5 +125,38 @@ describe("AgentRuntime", () => {
     ).rejects.toMatchObject({
       code: "TOOL_NOT_FOUND"
     });
+  });
+
+  it("registers and executes payment prep action through runtime", async () => {
+    const runtime = new AgentRuntime({ runtimeId: "runtime-payment-test" });
+    runtime.registerTool(createPaymentPrepTool());
+    await runtime.start();
+
+    const result = await runtime.executeTask<
+      PaymentPrepPayload,
+      PaymentPrepResult
+    >({
+      taskId: "task-pay-exec",
+      agentId: "agent-pay",
+      toolName: PAYMENT_PREP_TOOL_NAME,
+      input: "Prepare payment transaction",
+      payload: {
+        walletId: "GWALLET999",
+        amount: "50.00",
+        recipientId: "GRECEIVER111"
+      }
+    });
+
+    expect(result.output.status).toBe("prepared");
+    expect(result.output.amount).toBe("50.00");
+    expect(result.output.walletId).toBe("GWALLET999");
+    expect(result.output.recipientId).toBe("GRECEIVER111");
+    expect(result.output.assetCode).toBe("XLM");
+
+    const memory = await runtime
+      .getDependencies()
+      .memoryStore.listByAgent("agent-pay");
+    expect(memory).toHaveLength(1);
+    expect(memory[0]?.taskId).toBe("task-pay-exec");
   });
 });

--- a/tests/payment-prep-action.test.ts
+++ b/tests/payment-prep-action.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentInstanceManager,
+  createPaymentPrepTool,
+  InMemoryMemoryStore,
+  InMemoryRuntimeStateStore,
+  PAYMENT_PREP_TOOL_NAME,
+  RuntimeError,
+  UnconfiguredModelProvider
+} from "../src/index.js";
+import type { PaymentPrepPayload, RuntimeContext } from "../src/index.js";
+
+describe("PaymentPrepAction", () => {
+  const createMockContext = (taskId: string): RuntimeContext => ({
+    runtimeId: "runtime-test",
+    taskId,
+    agent: new AgentInstanceManager().getOrCreate("test-agent"),
+    memory: new InMemoryMemoryStore(),
+    modelProvider: new UnconfiguredModelProvider(),
+    state: new InMemoryRuntimeStateStore(),
+    now: "2026-08-30T12:00:00.000Z"
+  });
+
+  it("creates a tool with correct name and description metadata", () => {
+    const tool = createPaymentPrepTool();
+    expect(tool.name).toBe(PAYMENT_PREP_TOOL_NAME);
+    expect(tool.description).toContain(
+      "without performing live Stellar network calls"
+    );
+  });
+
+  it("prepares valid payment context and transaction stub", async () => {
+    const tool = createPaymentPrepTool();
+    const context = createMockContext("task-pay-1");
+
+    const payload: PaymentPrepPayload = {
+      walletId: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+      amount: "150.50",
+      recipientId: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      assetCode: "USDC",
+      memo: "Invoice #1024",
+      metadata: { priority: "high" }
+    };
+
+    const result = await tool.execute({ payload, context });
+
+    expect(result).toEqual({
+      status: "prepared",
+      walletId: payload.walletId,
+      amount: "150.50",
+      recipientId: payload.recipientId,
+      assetCode: "USDC",
+      memo: "Invoice #1024",
+      preparedAt: "2026-08-30T12:00:00.000Z",
+      transactionStubId: `stellar-stub-task-pay-1-${payload.walletId}`,
+      isSimulated: true,
+      metadata: { priority: "high" }
+    });
+  });
+
+  it("handles numeric amount and defaults assetCode to XLM", async () => {
+    const tool = createPaymentPrepTool();
+    const context = createMockContext("task-pay-2");
+
+    const result = await tool.execute({
+      payload: {
+        walletId: "GWALLET123",
+        amount: 25
+      },
+      context
+    });
+
+    expect(result.amount).toBe("25");
+    expect(result.assetCode).toBe("XLM");
+    expect(result.status).toBe("prepared");
+    expect(result.isSimulated).toBe(true);
+  });
+
+  it("rejects empty walletId", async () => {
+    const tool = createPaymentPrepTool();
+    const context = createMockContext("task-pay-3");
+
+    expect(() =>
+      tool.execute({
+        payload: {
+          walletId: "",
+          amount: "10"
+        },
+        context
+      })
+    ).toThrowError(RuntimeError);
+  });
+
+  it("rejects missing or empty amount", async () => {
+    const tool = createPaymentPrepTool();
+    const context = createMockContext("task-pay-4");
+
+    expect(() =>
+      tool.execute({
+        payload: {
+          walletId: "GWALLET123",
+          amount: ""
+        },
+        context
+      })
+    ).toThrowError(RuntimeError);
+  });
+
+  it("rejects negative or invalid numeric amount", async () => {
+    const tool = createPaymentPrepTool();
+    const context = createMockContext("task-pay-5");
+
+    expect(() =>
+      tool.execute({
+        payload: {
+          walletId: "GWALLET123",
+          amount: -50
+        },
+        context
+      })
+    ).toThrowError(RuntimeError);
+
+    expect(() =>
+      tool.execute({
+        payload: {
+          walletId: "GWALLET123",
+          amount: "invalid-amount"
+        },
+        context
+      })
+    ).toThrowError(RuntimeError);
+  });
+});


### PR DESCRIPTION
### Problem Summary
Autonomous tasks in AgentLily runtime require a structured mechanism to validate and prepare wallet payment context without triggering live on-chain operations.

---

### Root Cause Analysis
The runtime lacked a dedicated wallet-aware action definition and typed stub for payment preparation, parameter validation, and transaction stub generation.

---

### Solution & Implementation Details
1. Implemented `PaymentPrepPayload` and `PaymentPrepResult` interfaces supporting `walletId`, `amount`, `recipientId`, `assetCode`, `memo`, and `metadata`.
2. Implemented `createPaymentPrepTool()` action factory registered under `wallet.prepare_payment`.
3. Added validation for non-empty `walletId`, positive numeric `amount`, and default asset code (`XLM`).
4. Generated deterministic transaction stubs (`transactionStubId`) with simulation flags (`isSimulated: true`) without live Stellar network calls.
5. Exported payment preparation action and types from `src/index.ts`.
6. Added comprehensive unit tests in `tests/payment-prep-action.test.ts` and integration tests in `tests/agent-runtime.test.ts`.

---

### Verification & Test Results
```text
> npm run verify
> npm run format:check && npm run lint && npm run typecheck && npm run test

All matched files use Prettier code style!
eslint src tests vitest.config.ts (0 errors, 0 warnings)
tsc --noEmit (0 errors)
✓ tests/tool-registry.test.ts (1 test)
✓ tests/task-runner.test.ts (1 test)
✓ tests/payment-prep-action.test.ts (6 tests)
✓ tests/agent-runtime.test.ts (5 tests)
Test Files  4 passed (4)
Tests  13 passed (13)
```

---

### Issue Reference
Closes #1