### PR TITLE
feat(providers): add openai-compatible model provider adapter scaffold (Closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ are expected to become contributor work:
 
 - Wallet-aware and payment-aware actions
 - Persistent memory and state backends
-- Model provider integrations
+- Model provider integrations (an `OpenAICompatibleModelProvider` scaffold is available for experimentation; note that it is scaffolded and intentionally not production-complete)
 - Runtime policy engines and approval flows
 - Long-running orchestration and scheduling
 - Distributed execution and durable coordination

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { RuntimeEventBus } from "./events/runtime-events.js";
 export { InMemoryRuntimeLogger } from "./logger/runtime-logger.js";
 export { InMemoryMemoryStore } from "./memory/memory-store.js";
 export { UnconfiguredModelProvider } from "./providers/model-provider.js";
+export { OpenAICompatibleModelProvider } from "./providers/openai-compatible-provider.js";
 export { InMemoryRuntimeStateStore } from "./state/runtime-state.js";
 export { TaskRunner } from "./tasks/task-runner.js";
 export { ToolRegistry } from "./tools/tool-registry.js";
@@ -29,6 +30,7 @@ export type {
   ModelProvider,
   ModelResponse
 } from "./providers/model-provider.js";
+export type { OpenAICompatibleProviderOptions } from "./providers/openai-compatible-provider.js";
 export type { RuntimeStateStore } from "./state/runtime-state.js";
 export type { RuntimeTask, TaskExecutionResult } from "./tasks/task-types.js";
 export type { ToolDefinition, ToolInvocation } from "./tools/types.js";

--- a/src/providers/openai-compatible-provider.ts
+++ b/src/providers/openai-compatible-provider.ts
@@ -1,0 +1,129 @@
+import type {
+  ModelPrompt,
+  ModelProvider,
+  ModelResponse
+} from "./model-provider.js";
+
+export interface OpenAICompatibleProviderOptions {
+  apiKey: string;
+  baseUrl?: string | undefined;
+  model?: string | undefined;
+  timeoutMs?: number | undefined;
+  headers?: Record<string, string> | undefined;
+}
+
+export class OpenAICompatibleModelProvider implements ModelProvider {
+  public readonly name = "openai-compatible";
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly model: string;
+  private readonly timeoutMs: number | undefined;
+  private readonly customHeaders: Record<string, string> | undefined;
+
+  public constructor(options: OpenAICompatibleProviderOptions) {
+    if (
+      !options.apiKey ||
+      typeof options.apiKey !== "string" ||
+      options.apiKey.trim().length === 0
+    ) {
+      throw new Error(
+        "OpenAI-compatible provider requires a non-empty apiKey."
+      );
+    }
+
+    const rawBaseUrl = options.baseUrl ?? "https://api.openai.com/v1";
+    if (typeof rawBaseUrl !== "string" || rawBaseUrl.trim().length === 0) {
+      throw new Error("OpenAI-compatible provider requires a valid baseUrl.");
+    }
+
+    try {
+      new URL(rawBaseUrl);
+    } catch {
+      throw new Error(
+        `Invalid baseUrl provided to OpenAICompatibleModelProvider: "${rawBaseUrl}".`
+      );
+    }
+
+    this.apiKey = options.apiKey.trim();
+    this.baseUrl = rawBaseUrl.trim().replace(/\/+$/, "");
+    this.model = options.model?.trim() || "gpt-4o-mini";
+    this.timeoutMs = options.timeoutMs;
+    this.customHeaders = options.headers;
+  }
+
+  public getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  public getModel(): string {
+    return this.model;
+  }
+
+  public async generate(prompt: ModelPrompt): Promise<ModelResponse> {
+    const url = `${this.baseUrl}/chat/completions`;
+    const payload = {
+      model: this.model,
+      messages: [
+        { role: "system", content: prompt.instructions },
+        { role: "user", content: prompt.input }
+      ]
+    };
+
+    let response: Response;
+    const requestInit: RequestInit = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+        ...(this.customHeaders ?? {})
+      },
+      body: JSON.stringify(payload)
+    };
+
+    if (this.timeoutMs !== undefined) {
+      requestInit.signal = AbortSignal.timeout(this.timeoutMs);
+    }
+
+    try {
+      response = await fetch(url, requestInit);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`OpenAI-compatible provider request failed: ${message}`);
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      throw new Error(
+        `OpenAI-compatible provider returned HTTP ${response.status}: ${errorText}`
+      );
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{
+        message?: {
+          content?: string;
+        };
+        finish_reason?: string;
+      }>;
+      usage?: Record<string, unknown>;
+      model?: string;
+    };
+
+    const outputText = data.choices?.[0]?.message?.content ?? "";
+    const metadata: Record<string, unknown> = {
+      model: data.model ?? this.model
+    };
+
+    if (data.choices?.[0]?.finish_reason !== undefined) {
+      metadata.finishReason = data.choices[0].finish_reason;
+    }
+    if (data.usage !== undefined) {
+      metadata.usage = data.usage;
+    }
+
+    return {
+      outputText,
+      metadata
+    };
+  }
+}

--- a/tests/openai-compatible-provider.test.ts
+++ b/tests/openai-compatible-provider.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  OpenAICompatibleModelProvider,
+  type ModelPrompt
+} from "../src/index.js";
+
+describe("OpenAICompatibleModelProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("validates configuration and throws on missing apiKey", () => {
+    expect(
+      () => new OpenAICompatibleModelProvider({ apiKey: "" })
+    ).toThrowError("OpenAI-compatible provider requires a non-empty apiKey.");
+
+    expect(
+      () =>
+        new OpenAICompatibleModelProvider({
+          apiKey: "   "
+        })
+    ).toThrowError("OpenAI-compatible provider requires a non-empty apiKey.");
+  });
+
+  it("validates configuration and throws on invalid baseUrl", () => {
+    expect(
+      () =>
+        new OpenAICompatibleModelProvider({
+          apiKey: "valid-key",
+          baseUrl: "not-a-valid-url"
+        })
+    ).toThrowError(
+      'Invalid baseUrl provided to OpenAICompatibleModelProvider: "not-a-valid-url".'
+    );
+  });
+
+  it("initializes with default options", () => {
+    const provider = new OpenAICompatibleModelProvider({
+      apiKey: "sk-test-key"
+    });
+
+    expect(provider.name).toBe("openai-compatible");
+    expect(provider.getBaseUrl()).toBe("https://api.openai.com/v1");
+    expect(provider.getModel()).toBe("gpt-4o-mini");
+  });
+
+  it("generates model response with mocked HTTP success", async () => {
+    const mockResponsePayload = {
+      id: "chatcmpl-test",
+      model: "gpt-4o-mini",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "Autonomous payment prepared successfully."
+          },
+          finish_reason: "stop"
+        }
+      ],
+      usage: {
+        prompt_tokens: 15,
+        completion_tokens: 8,
+        total_tokens: 23
+      }
+    };
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResponsePayload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    );
+
+    const provider = new OpenAICompatibleModelProvider({
+      apiKey: "sk-mock-key",
+      model: "gpt-4o-mini"
+    });
+
+    const prompt: ModelPrompt = {
+      instructions: "You are an autonomous Stellar agent.",
+      input: "Prepare 10 XLM payment to recipient."
+    };
+
+    const response = await provider.generate(prompt);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer sk-mock-key"
+        }),
+        body: JSON.stringify({
+          model: "gpt-4o-mini",
+          messages: [
+            { role: "system", content: prompt.instructions },
+            { role: "user", content: prompt.input }
+          ]
+        })
+      })
+    );
+
+    expect(response.outputText).toBe(
+      "Autonomous payment prepared successfully."
+    );
+    expect(response.metadata).toEqual({
+      model: "gpt-4o-mini",
+      finishReason: "stop",
+      usage: {
+        prompt_tokens: 15,
+        completion_tokens: 8,
+        total_tokens: 23
+      }
+    });
+  });
+
+  it("supports custom baseUrl and custom headers", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          model: "custom-llm",
+          choices: [{ message: { content: "Custom response" } }]
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const provider = new OpenAICompatibleModelProvider({
+      apiKey: "custom-token",
+      baseUrl: "https://custom-llm.example.com/v1/",
+      model: "custom-llm",
+      headers: { "X-Custom-Header": "custom-val" }
+    });
+
+    const response = await provider.generate({
+      instructions: "Instructions",
+      input: "Input"
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://custom-llm.example.com/v1/chat/completions",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "X-Custom-Header": "custom-val",
+          Authorization: "Bearer custom-token"
+        })
+      })
+    );
+    expect(response.outputText).toBe("Custom response");
+  });
+
+  it("handles non-2xx HTTP responses with descriptive error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Invalid API key" }), {
+        status: 401,
+        statusText: "Unauthorized"
+      })
+    );
+
+    const provider = new OpenAICompatibleModelProvider({
+      apiKey: "invalid-key"
+    });
+
+    await expect(
+      provider.generate({ instructions: "test", input: "test" })
+    ).rejects.toThrowError(
+      'OpenAI-compatible provider returned HTTP 401: {"error":"Invalid API key"}'
+    );
+  });
+
+  it("handles network failure gracefully", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
+      new Error("ECONNREFUSED")
+    );
+
+    const provider = new OpenAICompatibleModelProvider({
+      apiKey: "valid-key"
+    });
+
+    await expect(
+      provider.generate({ instructions: "test", input: "test" })
+    ).rejects.toThrowError(
+      "OpenAI-compatible provider request failed: ECONNREFUSED"
+    );
+  });
+});


### PR DESCRIPTION
### Problem Summary
AgentLily requires a structured model provider adapter behind the existing `ModelProvider` interface to enable integrations and testing with OpenAI-compatible LLM backends.

---

### Root Cause Analysis
The runtime supplied only an `UnconfiguredModelProvider` placeholder without a lightweight adapter implementing the chat completion payload and response contract.

---

### Solution & Implementation Details
1. Implemented `OpenAICompatibleModelProvider` implementing `ModelProvider` using standard `fetch` without heavy external SDK dependencies.
2. Added configuration validation for `apiKey`, `baseUrl`, `model`, `timeoutMs`, and optional custom headers.
3. Handled system/user message framing, choice extraction, metadata/usage parsing, and descriptive HTTP error responses.
4. Exported `OpenAICompatibleModelProvider` and `OpenAICompatibleProviderOptions` from `src/index.ts`.
5. Updated `README.md` noting the adapter as scaffolded for experimentation.
6. Added comprehensive unit tests with mocked HTTP responses covering happy paths, config validation, custom headers, and network/HTTP errors in `tests/openai-compatible-provider.test.ts`.

---

### Verification & Test Results
```text
> npm run verify
> npm run format:check && npm run lint && npm run typecheck && npm run test

All matched files use Prettier code style!
eslint src tests vitest.config.ts (0 errors, 0 warnings)
tsc --noEmit (0 errors)
✓ tests/tool-registry.test.ts (1 test)
✓ tests/task-runner.test.ts (1 test)
✓ tests/agent-runtime.test.ts (4 tests)
✓ tests/openai-compatible-provider.test.ts (7 tests)
Test Files  4 passed (4)
Tests  13 passed (13)
```

---

### Issue Reference
Closes #3