### PR TITLE
feat: add shutdown method to AgentRuntime

### DIFF
--- a/src/events/runtime-events.ts
+++ b/src/events/runtime-events.ts
@@ -1,5 +1,6 @@
 export interface RuntimeEventMap {
   "runtime.started": { runtimeId: string; occurredAt: string };
+  "runtime.stopped": { runtimeId: string; occurredAt: string };
   "runtime.task.received": {
     runtimeId: string;
     taskId: string;

--- a/src/runtime/agent-runtime.ts
+++ b/src/runtime/agent-runtime.ts
@@ -43,6 +43,24 @@ export class AgentRuntime {
     });
   }
 
+  public async stop(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+
+    this.started = false;
+    this.dependencies.logger.info("Runtime stopped.", {
+      runtimeId: this.runtimeId
+    });
+    this.dependencies.eventBus.emit({
+      name: "runtime.stopped",
+      payload: {
+        runtimeId: this.runtimeId,
+        occurredAt: new Date().toISOString()
+      }
+    });
+  }
+
   public async executeTask<TPayload, TResult>(
     task: RuntimeTask<TPayload>
   ): Promise<TaskExecutionResult<TResult>> {


### PR DESCRIPTION
Closes #135

## Changes
- Added async `stop()` method to `AgentRuntime` that marks the runtime as stopped and emits `runtime.stopped` event
- Idempotent: calling `stop()` on an already-stopped runtime is a safe no-op
- Subsequent `executeTask()` calls correctly reject via existing `assertRuntimeStarted` guard
- Registered `runtime.stopped` in `RuntimeEventMap` for full type safety

## Verification
- TypeScript compilation passes with zero errors (`tsc --noEmit`)
- Event payload matches `runtime.started` structure for consistency