### PR TITLE
fix: add toJSON serialization to RuntimeError

### DIFF
--- a/src/errors/runtime-errors.ts
+++ b/src/errors/runtime-errors.ts
@@ -20,4 +20,20 @@ export class RuntimeError extends Error {
     this.code = code;
     this.details = details;
   }
+
+  public toJSON(): {
+    name: string;
+    code: RuntimeErrorCode;
+    message: string;
+    details: Record<string, unknown> | undefined;
+    stack: string | undefined;
+  } {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      details: this.details,
+      stack: this.stack
+    };
+  }
 }

--- a/tests/runtime-errors.test.ts
+++ b/tests/runtime-errors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { RuntimeError } from "../src/index.js";
+
+describe("RuntimeError", () => {
+  it("serializes name, code, message, details, and stack via toJSON", () => {
+    const details = { toolName: "echo", attempt: 3 };
+    const err = new RuntimeError("EXECUTION_FAILED", "Execution failed", details);
+
+    const json = err.toJSON();
+
+    expect(json.name).toBe("RuntimeError");
+    expect(json.code).toBe("EXECUTION_FAILED");
+    expect(json.message).toBe("Execution failed");
+    expect(json.details).toEqual(details);
+    expect(typeof json.stack).toBe("string");
+  });
+
+  it("survives JSON.stringify losslessly", () => {
+    const details = { toolName: "echo" };
+    const err = new RuntimeError("TOOL_NOT_FOUND", "Tool not found", details);
+
+    const parsed = JSON.parse(JSON.stringify(err)) as {
+      name: string;
+      code: string;
+      message: string;
+      details: Record<string, unknown>;
+      stack: string | undefined;
+    };
+
+    expect(parsed.name).toBe("RuntimeError");
+    expect(parsed.code).toBe("TOOL_NOT_FOUND");
+    expect(parsed.message).toBe("Tool not found");
+    expect(parsed.details).toEqual(details);
+    expect(typeof parsed.stack).toBe("string");
+  });
+
+  it("includes details when undefined", () => {
+    const err = new RuntimeError("RUNTIME_NOT_STARTED", "Runtime not started");
+
+    expect(err.toJSON().details).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(err)).details).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Overview
Adds a `toJSON()` method to `RuntimeError` in `src/errors/runtime-errors.ts` so that `code`, `details`, plus `name`, `message`, and `stack` survive `JSON.stringify` losslessly — important for logs and API responses. A dedicated vitest suite confirms the serialization behavior.

## Related Issue
Closes #155

## Changes
- [MODIFY] `src/errors/runtime-errors.ts` — add `toJSON()` returning `{ name, code, message, details, stack }`
- [ADD] `tests/runtime-errors.test.ts` — tests for `toJSON()`, lossless `JSON.stringify`, and undefined `details`

## Verification Results
Verified by code inspection; a local checkout was not created. The repository CI (`npm run verify`) runs `npm run format:check`, `npm run lint`, `npm run typecheck`, and `npm run test` (vitest with coverage). The added tests cover the `toJSON()` path, `JSON.stringify` round-trip including `code`, `details`, and `stack`, and the undefined-`details` case. The change is type-safe under the project strict `tsconfig.json`.

| Acceptance Criteria | Status |
| --- | --- |
| `toJSON()` added | ✅ Added to `RuntimeError` |
| `code` and `details` survive `JSON.stringify` | ✅ Covered by round-trip test |
| Stack included | ✅ `stack` returned by `toJSON()` and asserted in tests |
