### PR TITLE
test: move event suites out of src coverage

### DIFF
--- a/tests/events/src-runtime-events.test.ts
+++ b/tests/events/src-runtime-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { RuntimeEventBus } from "../runtime-events.js";
+import { RuntimeEventBus } from "../../src/events/runtime-events.js";
 
 describe("RuntimeEventBus max listeners", () => {
   it("warns when exceeding maxListenersPerEvent", () => {

--- a/tests/events/src-runtime-internal-error.test.ts
+++ b/tests/events/src-runtime-internal-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { RuntimeEventBus } from "../runtime-events.js";
+import { RuntimeEventBus } from "../../src/events/runtime-events.js";
 
 describe("RuntimeEventBus runtime.internal.error", () => {
   it("emits runtime.internal.error when a listener throws", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
       exclude: [
+        "src/**/__tests__/**",
         "src/**/types.ts",
         "src/runtime/context.ts",
         "src/tasks/task-types.ts",


### PR DESCRIPTION
Fixes #268

## Summary

- Move `src/events/__tests__/runtime-events.test.ts` to `tests/events/src-runtime-events.test.ts`.
- Move `src/events/__tests__/runtime-internal-error.test.ts` to `tests/events/src-runtime-internal-error.test.ts`.
- Update the moved suites' imports and add an explicit `src/**/__tests__/**` coverage exclusion as a defensive, documented production-coverage boundary.

## Empirical coverage finding

Vitest 3.2.4 already excludes `**/__tests__/**` through its default coverage exclusions. These suites were therefore not present in the coverage denominator on the gated baseline; relocating them changes the repository layout and makes the intended boundary explicit, but does not fabricate a coverage change or require threshold changes.

Before and after:

- Test files: 55 -> 55
- Tests: 226 -> 226
- Lines: 94.76% -> 94.76%
- Functions: 89.58% -> 89.58%
- Branches: 91.44% -> 91.44%
- Statements: 94.76% -> 94.76%
- No `src/**/__tests__` directory remains.

## Validation

- `npm run verify` — PASS
- Focused relocated event tests — 2 files / 6 tests passed
- `npm run build` — PASS
- `git diff --check` — PASS
