### PR TITLE
test(runtime): assert RUNTIME_ALREADY_STOPPED on restart after stop (#227)

### DIFF
--- a/tests/errors/runtime-errors.test.ts
+++ b/tests/errors/runtime-errors.test.ts
@@ -37,6 +37,7 @@ describe("RuntimeError construction and code values (Issue #110)", () => {
     const codes = [
       "RUNTIME_NOT_STARTED",
       "RUNTIME_ALREADY_STARTED",
+      "RUNTIME_ALREADY_STOPPED",
       "TOOL_NOT_FOUND",
       "DUPLICATE_TOOL",
       "INVALID_TASK",

--- a/tests/runtime/double-start-error.test.ts
+++ b/tests/runtime/double-start-error.test.ts
@@ -17,6 +17,24 @@ describe("AgentRuntime double-start rejection", () => {
     }
   });
 
+  it("throws RUNTIME_ALREADY_STOPPED when restarted after stop", async () => {
+    const runtime = new AgentRuntime({ runtimeId: "restart-after-stop-test" });
+    await runtime.start();
+    await runtime.stop();
+
+    try {
+      await runtime.start();
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RuntimeError);
+      const err = e as RuntimeError;
+      expect(err.code).toBe("RUNTIME_ALREADY_STOPPED");
+      expect(err.message).toContain(
+        "already been stopped and cannot be restarted"
+      );
+    }
+  });
+
   it("does not emit runtime.started event twice", async () => {
     const { RuntimeEventBus } =
       await import("../../src/events/runtime-events.js");


### PR DESCRIPTION
## Summary
Resolves #227.

This PR satisfies all acceptance criteria for issue #227:
1. Validates that `RuntimeErrorCode` in `src/errors/runtime-errors.ts` includes `"RUNTIME_ALREADY_STOPPED"` and typecheck passes cleanly.
2. Adds unit test asserting that calling `start()` then `stop()` then `start()` on `AgentRuntime` throws `RuntimeError` with `err.code === "RUNTIME_ALREADY_STOPPED"` and message mentioning that it cannot be restarted.
3. Updates `tests/errors/runtime-errors.test.ts` to include `"RUNTIME_ALREADY_STOPPED"` in the supported runtime error codes test array.
4. Preserves the existing `RUNTIME_ALREADY_STARTED` double-start behavior and test suite.

## Verification
- `npm run typecheck` (`tsc --noEmit`): clean with 0 errors.
- `npx vitest run tests/runtime/double-start-error.test.ts tests/errors/runtime-errors.test.ts`: 10/10 tests pass.
- Full test suite `npx vitest run`: all 55 test files and 227 tests pass.
- `npm run lint`: 0 errors.

## Checklist
- [x] Tests added or updated
- [x] Public interfaces remain intentionally extendable
- [x] Documentation updated where relevant
- [x] Scope stays focused on one architectural concern
