### PR TITLE
feat(providers): route UnconfiguredModelProvider placeholder warnings through injected RuntimeLogger (Closes #264)

### DIFF
--- a/src/providers/model-provider.ts
+++ b/src/providers/model-provider.ts
@@ -1,3 +1,5 @@
+import type { RuntimeLogger } from "../logger/runtime-logger.js";
+
 export interface ModelPrompt {
   instructions: string;
   input: string;
@@ -15,13 +17,23 @@ export interface ModelProvider {
 
 export class UnconfiguredModelProvider implements ModelProvider {
   public readonly name = "unconfigured";
+  private readonly logger: RuntimeLogger | undefined;
+
+  public constructor(logger?: RuntimeLogger) {
+    this.logger = logger;
+  }
 
   public async generate(prompt: ModelPrompt): Promise<ModelResponse> {
-    console.warn(
+    const warningMessage =
       "UnconfiguredModelProvider: no model provider is configured. " +
-        "generate() was called but will return placeholder text. " +
-        "Configure a real ModelProvider to enable AI-powered task execution."
-    );
+      "generate() was called but will return placeholder text. " +
+      "Configure a real ModelProvider to enable AI-powered task execution.";
+
+    if (this.logger) {
+      this.logger.warn(warningMessage);
+    } else {
+      console.warn(warningMessage);
+    }
 
     return {
       outputText:

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -25,9 +25,9 @@ export function createRuntimeDependencies(options: RuntimeOptions) {
     (options.memoryStoragePath
       ? new JsonFileMemoryStore(options.memoryStoragePath)
       : new InMemoryMemoryStore());
-  const modelProvider =
-    options.modelProvider ?? new UnconfiguredModelProvider();
   const logger = options.logger ?? new ConsoleRuntimeLogger();
+  const modelProvider =
+    options.modelProvider ?? new UnconfiguredModelProvider(logger);
   const stateStore = options.stateStore ?? new InMemoryRuntimeStateStore();
   const eventBus = options.eventBus ?? new RuntimeEventBus();
   const agentManager = new AgentInstanceManager();

--- a/tests/providers/unconfigured-logger-routing.test.ts
+++ b/tests/providers/unconfigured-logger-routing.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { AgentRuntime } from "../../src/runtime/agent-runtime.js";
+import {
+  ConsoleRuntimeLogger,
+  InMemoryRuntimeLogger,
+  type RuntimeLogger
+} from "../../src/logger/runtime-logger.js";
+import { UnconfiguredModelProvider } from "../../src/providers/model-provider.js";
+
+describe("UnconfiguredModelProvider logger routing", () => {
+  it("routes placeholder warning through injected logger in AgentRuntime", async () => {
+    const logger = new InMemoryRuntimeLogger();
+    const runtime = new AgentRuntime({ logger });
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const prompt = { instructions: "test instructions", input: "test input" };
+    const response = await runtime.getDependencies().modelProvider.generate(prompt);
+
+    expect(response.outputText).toContain("No model provider is configured");
+    expect(response.metadata?.warning).toBe("unconfigured_provider");
+
+    // Must NOT write to raw console.warn
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    // Must record warn entry in the injected logger
+    expect(logger.entries.length).toBe(1);
+    expect(logger.entries[0]?.level).toBe("warn");
+    expect(logger.entries[0]?.message).toContain(
+      "UnconfiguredModelProvider: no model provider is configured"
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("respects logger minimum level filtering via ConsoleRuntimeLogger (suppressed at error level)", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const logger = new ConsoleRuntimeLogger({ level: "error" });
+    const runtime = new AgentRuntime({ logger });
+
+    await runtime.getDependencies().modelProvider.generate({ instructions: "a", input: "b" });
+
+    // ConsoleRuntimeLogger with level="error" suppresses warn entries
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("respects custom logger level filtering", async () => {
+    const warnMock = vi.fn();
+    const customLogger: RuntimeLogger = {
+      level: "error",
+      info: vi.fn(),
+      warn: (msg, meta) => {
+        if (customLogger.level !== "error") {
+          warnMock(msg, meta);
+        }
+      },
+      debug: vi.fn(),
+      error: vi.fn()
+    };
+
+    const runtime = new AgentRuntime({ logger: customLogger });
+    await runtime.getDependencies().modelProvider.generate({ instructions: "a", input: "b" });
+
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to console.warn when UnconfiguredModelProvider is constructed without a logger", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const provider = new UnconfiguredModelProvider();
+
+    await provider.generate({ instructions: "test", input: "hello" });
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy.mock.calls[0]![0]).toContain(
+      "UnconfiguredModelProvider: no model provider is configured"
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
### Summary of Changes
- Updated `UnconfiguredModelProvider` to accept an optional `logger?: RuntimeLogger` in its constructor.
- When a logger is provided, placeholder warnings are routed through `logger.warn(...)`, honoring configured level filtering and redaction; falls back to `console.warn(...)` when no logger is present.
- Updated `createRuntimeDependencies()` in `src/runtime/bootstrap.ts` to instantiate `logger` before `modelProvider` and pass it into `new UnconfiguredModelProvider(logger)`.
- Added comprehensive unit tests in `tests/providers/unconfigured-logger-routing.test.ts` verifying:
  1. Default provider warnings are routed to injected logger in `AgentRuntime` instead of raw `console.warn`.
  2. Injected logger level filtering is respected (suppressed at `error` level).
  3. Direct construction without a logger still falls back to `console.warn`.
- Existing tests in `tests/providers/unconfigured-warn.test.ts` continue to pass.

Closes #264