### PR TITLE
test(agents): add tests for AgentInstanceManager FIFO eviction at maxInstances (Closes #241)

### DIFF
--- a/tests/agents/agent-instance-manager.test.ts
+++ b/tests/agents/agent-instance-manager.test.ts
@@ -51,4 +51,41 @@ describe("AgentInstanceManager getOrCreate identity semantics (Issue #113)", () 
       /agentId must be a non-empty string/
     );
   });
+
+  it("evicts the oldest agent when creating maxInstances + 1 instances", () => {
+    const manager = new AgentInstanceManager({ maxInstances: 3 });
+
+    manager.getOrCreate("agent-1");
+    manager.getOrCreate("agent-2");
+    manager.getOrCreate("agent-3");
+
+    expect(manager.size()).toBe(3);
+    expect(manager.has("agent-1")).toBe(true);
+
+    // Creating a 4th agent must evict agent-1 (the oldest)
+    const agent4 = manager.getOrCreate("agent-4");
+    expect(manager.size()).toBe(3);
+    expect(manager.has("agent-1")).toBe(false);
+    expect(manager.get("agent-1")).toBeUndefined();
+    expect(manager.has("agent-2")).toBe(true);
+    expect(manager.has("agent-3")).toBe(true);
+    expect(manager.has("agent-4")).toBe(true);
+
+    const activeIds = manager.list().map((i) => i.agentId);
+    expect(activeIds).toEqual(["agent-2", "agent-3", "agent-4"]);
+    expect(activeIds).not.toContain("agent-1");
+  });
+
+  it("never evicts when configured with maxInstances: 0 (unbounded)", () => {
+    const manager = new AgentInstanceManager({ maxInstances: 0 });
+
+    for (let i = 1; i <= 20; i++) {
+      manager.getOrCreate(`agent-${i}`);
+    }
+
+    expect(manager.size()).toBe(20);
+    for (let i = 1; i <= 20; i++) {
+      expect(manager.has(`agent-${i}`)).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
### Summary of Changes
- Added unit tests in `tests/agents/agent-instance-manager.test.ts` verifying FIFO eviction when exceeding `maxInstances`.
- Asserts that creating `maxInstances + 1` agents deletes the oldest instance from internal storage (`has()` returns `false`, `get()` returns `undefined`, and `list()` excludes the evicted agent).
- Asserts that configuring `maxInstances: 0` enables unbounded creation mode where no eviction occurs.
- All unit tests in the suite pass cleanly.

Closes #241