### PR TITLE
fix(memory): snapshot tool outputs when appending history in InMemoryMemoryStore (#260)

### DIFF
--- a/src/memory/memory-store.ts
+++ b/src/memory/memory-store.ts
@@ -41,6 +41,21 @@ export interface MemoryStore {
 export const DEFAULT_MAX_MEMORY_ENTRIES = 10_000;
 export const DEFAULT_MAX_MEMORY_ENTRIES_PER_AGENT = 1_000;
 
+const cloneOutput = (val: unknown): unknown => {
+  if (val === null || typeof val !== "object") {
+    return val;
+  }
+  try {
+    return structuredClone(val);
+  } catch {
+    try {
+      return JSON.parse(JSON.stringify(val));
+    } catch {
+      return val;
+    }
+  }
+};
+
 export class InMemoryMemoryStore implements MemoryStore {
   private readonly entries: MemoryEntry[] = [];
 
@@ -75,7 +90,7 @@ export class InMemoryMemoryStore implements MemoryStore {
       agentId: entry.agentId,
       taskId: entry.taskId,
       input: entry.input,
-      output: entry.output,
+      output: cloneOutput(entry.output),
       recordedAt: entry.recordedAt
     };
 
@@ -115,7 +130,10 @@ export class InMemoryMemoryStore implements MemoryStore {
     const limit = options?.limit ?? matching.length;
 
     const slice = matching.slice(offset, offset + limit);
-    return slice.map((entry) => ({ ...entry }));
+    return slice.map((entry) => ({
+      ...entry,
+      output: cloneOutput(entry.output)
+    }));
   }
 
   public async countByAgent(agentId: string): Promise<number> {

--- a/tests/memory/snapshot-outputs.test.ts
+++ b/tests/memory/snapshot-outputs.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryMemoryStore, type MemoryEntry } from "../../src/memory/memory-store.js";
+
+describe("InMemoryMemoryStore snapshot outputs (#260)", () => {
+  it("snapshots output on append so mutating the original object does not corrupt stored history", async () => {
+    const store = new InMemoryMemoryStore();
+    const outputData: { nested: { count: number; items: string[] } } = {
+      nested: {
+        count: 1,
+        items: ["alpha"],
+      },
+    };
+
+    const entry: MemoryEntry = {
+      agentId: "agent-1",
+      taskId: "task-1",
+      input: "do work",
+      output: outputData,
+      recordedAt: new Date().toISOString(),
+    };
+
+    await store.append(entry);
+
+    // Mutate the original output object
+    outputData.nested.count = 999;
+    outputData.nested.items.push("beta", "gamma");
+
+    const history = await store.listByAgent("agent-1");
+    expect(history).toHaveLength(1);
+    expect(history[0]?.output).toEqual({
+      nested: {
+        count: 1,
+        items: ["alpha"],
+      },
+    });
+  });
+
+  it("returns independent copies from listByAgent so caller mutations do not affect subsequent reads", async () => {
+    const store = new InMemoryMemoryStore();
+    const outputData = { results: ["foo", "bar"], meta: { score: 10 } };
+
+    await store.append({
+      agentId: "agent-1",
+      taskId: "task-2",
+      input: "test",
+      output: outputData,
+      recordedAt: new Date().toISOString(),
+    });
+
+    const firstRead = await store.listByAgent("agent-1");
+    expect(firstRead).toHaveLength(1);
+
+    // Mutate the returned entry and output
+    (firstRead[0]?.output as { results: string[] }).results.push("corrupted");
+    (firstRead[0]?.output as { meta: { score: number } }).meta.score = 0;
+
+    const secondRead = await store.listByAgent("agent-1");
+    expect(secondRead).toHaveLength(1);
+    expect(secondRead[0]?.output).toEqual({
+      results: ["foo", "bar"],
+      meta: { score: 10 },
+    });
+  });
+
+  it("handles primitive, null, and non-plain outputs gracefully", async () => {
+    const store = new InMemoryMemoryStore();
+
+    await store.append({
+      agentId: "agent-1",
+      taskId: "task-primitive",
+      input: "p",
+      output: "string-output",
+      recordedAt: new Date().toISOString(),
+    });
+
+    await store.append({
+      agentId: "agent-1",
+      taskId: "task-null",
+      input: "n",
+      output: null,
+      recordedAt: new Date().toISOString(),
+    });
+
+    const results = await store.listByAgent("agent-1");
+    expect(results).toHaveLength(2);
+    expect(results[0]?.output).toBe("string-output");
+    expect(results[1]?.output).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #260

### Context & Problem
`InMemoryMemoryStore.append()` previously performed only a shallow object clone of the incoming entry and assigned `entry.output` by reference. Similarly, `listByAgent()` returned shallow clones of the stored entry records. If a caller or tool subsequently mutated the output object, previously recorded execution history was silently corrupted in memory, breaking point-in-time auditability.

### Proposed Changes
- Introduced a deep snapshotting helper `cloneOutput()` using `structuredClone` (with fallback to JSON serialization and graceful fallback for non-cloneable objects).
- Cloned `output` defensively during `InMemoryMemoryStore.append()`.
- Returned defensive deep copies of `output` on `InMemoryMemoryStore.listByAgent()`.
- Added unit tests in `tests/memory/snapshot-outputs.test.ts` asserting that post-append mutations and mutations to returned read lists do not mutate stored history.

### Validation
- `npm run typecheck`: Passed (0 errors)
- `npm run lint`: Passed (0 errors)
- `npx vitest run tests/memory/snapshot-outputs.test.ts`: 3/3 tests passed
