### PR TITLE
test(runtime): assert memoryStoragePath selects JsonFileMemoryStore and persists history (Closes #245)

### DIFF
--- a/tests/runtime/create-runtime-deps.test.ts
+++ b/tests/runtime/create-runtime-deps.test.ts
@@ -1,12 +1,32 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { createRuntimeDependencies } from "../../src/runtime/bootstrap.js";
-import { InMemoryMemoryStore } from "../../src/memory/memory-store.js";
+import {
+  InMemoryMemoryStore,
+  JsonFileMemoryStore
+} from "../../src/memory/memory-store.js";
 import { UnconfiguredModelProvider } from "../../src/providers/model-provider.js";
 import { ConsoleRuntimeLogger } from "../../src/logger/runtime-logger.js";
 import { InMemoryRuntimeStateStore } from "../../src/state/runtime-state.js";
 import { RuntimeEventBus } from "../../src/events/runtime-events.js";
+import { AgentRuntime } from "../../src/runtime/agent-runtime.js";
+import type { ToolDefinition } from "../../src/tools/types.js";
 
 describe("createRuntimeDependencies default wiring (Issue #114)", () => {
+  const createdDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const dir of createdDirs) {
+      if (existsSync(dir)) {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+    createdDirs.length = 0;
+  });
+
   it("provides all required dependency keys with non-null instances", () => {
     const deps = createRuntimeDependencies({ runtimeId: "default-wiring" });
     expect(deps.actionExecutor).toBeDefined();
@@ -61,5 +81,76 @@ describe("createRuntimeDependencies default wiring (Issue #114)", () => {
       eventBus: customBus
     });
     expect(deps.eventBus).toBe(customBus);
+  });
+
+  it("selects JsonFileMemoryStore with matching filePath when memoryStoragePath is provided (Issue #245)", () => {
+    const dir = join(
+      tmpdir(),
+      `agentlily-deps-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    createdDirs.push(dir);
+    const storagePath = join(dir, "memory.json");
+
+    const deps = createRuntimeDependencies({
+      runtimeId: "durable-mem-deps",
+      memoryStoragePath: storagePath
+    });
+
+    expect(deps.memoryStore).toBeInstanceOf(JsonFileMemoryStore);
+    const fileStore = deps.memoryStore as JsonFileMemoryStore;
+    expect(fileStore.getFilePath()).toBe(storagePath);
+  });
+
+  it("persists task execution results to memoryStoragePath across runtime instances (Issue #245)", async () => {
+    const dir = join(
+      tmpdir(),
+      `agentlily-deps-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    createdDirs.push(dir);
+    const storagePath = join(dir, "task-history.json");
+
+    const echoTool: ToolDefinition<{ text: string }, { echoed: string }> = {
+      name: "echo",
+      description: "Echoes input text",
+      execute: async ({ payload }) => ({ echoed: payload.text })
+    };
+
+    const runtime1 = new AgentRuntime({
+      runtimeId: "rt-persist-1",
+      memoryStoragePath: storagePath,
+      tools: [echoTool]
+    });
+
+    await runtime1.start();
+    const result = await runtime1.executeTask({
+      taskId: "task-persist-1",
+      agentId: "agent-durable",
+      toolName: "echo",
+      input: JSON.stringify({ text: "hello durable world" }),
+      payload: { text: "hello durable world" }
+    });
+
+    expect(result.output).toEqual({ echoed: "hello durable world" });
+    expect(result.taskId).toBe("task-persist-1");
+    expect(result.agentId).toBe("agent-durable");
+    expect(result.toolName).toBe("echo");
+    await runtime1.stop();
+
+    // Verify file exists on disk
+    expect(existsSync(storagePath)).toBe(true);
+
+    // Create a second runtime pointing to the same storage path and check persistence
+    const runtime2 = new AgentRuntime({
+      runtimeId: "rt-persist-2",
+      memoryStoragePath: storagePath
+    });
+
+    const secondStore = runtime2.getDependencies().memoryStore;
+    const history = await secondStore.listByAgent("agent-durable");
+    expect(history).toHaveLength(1);
+    expect(history[0]?.taskId).toBe("task-persist-1");
+    expect(history[0]?.agentId).toBe("agent-durable");
+    expect(history[0]?.input).toBe(JSON.stringify({ text: "hello durable world" }));
+    expect(history[0]?.output).toEqual({ echoed: "hello durable world" });
   });
 });


### PR DESCRIPTION
### Summary
Closes #245

Adds test coverage for `createRuntimeDependencies` durable storage configuration and end-to-end task history persistence:
- Asserts that providing `memoryStoragePath` selects `JsonFileMemoryStore` with `getFilePath()` matching the provided path.
- Asserts that omitting `memoryStoragePath` continues to select `InMemoryMemoryStore`.
- Asserts end-to-end task execution persistence with `AgentRuntime` when configured with `memoryStoragePath`, validating that task results are written to disk and can be retrieved by another runtime instance / store sharing the same file path.

### Verification
- `npx vitest run tests/runtime/create-runtime-deps.test.ts` passes (10/10 tests)
- `npm run build` passes cleanly
