### PR TITLE
fix(coverage): exclude src/**/__tests__ from coverage and relocate test suites (closes #268)

### DIFF
--- a/tests/events/runtime-events-max-listeners.test.ts
+++ b/tests/events/runtime-events-max-listeners.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { RuntimeEventBus } from "../runtime-events.js";
+import { RuntimeEventBus } from "../../src/events/runtime-events.js";
 
 describe("RuntimeEventBus max listeners", () => {
   it("warns when exceeding maxListenersPerEvent", () => {

--- a/tests/events/runtime-internal-error-listener.test.ts
+++ b/tests/events/runtime-internal-error-listener.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { RuntimeEventBus } from "../runtime-events.js";
+import { RuntimeEventBus } from "../../src/events/runtime-events.js";
 
 describe("RuntimeEventBus runtime.internal.error", () => {
   it("emits runtime.internal.error when a listener throws", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
       exclude: [
+        "src/**/__tests__/**",
         "src/**/types.ts",
         "src/runtime/context.ts",
         "src/tasks/task-types.ts",


### PR DESCRIPTION
## Summary
Closes #268

- Adds  to  coverage exclusions so test fixtures placed under  are not counted towards source code coverage metrics.
- Relocates existing test suites from  to  ( and ) keeping the repository's convention of top-level  directory consistent.

## Verification
-  passes (format, lint, typecheck, tests).
- Coverage correctly measures runtime sources without skewing from test files under .
