### PR TITLE
fix(events): make completion duration part of the event contract

### DIFF
--- a/src/events/runtime-events.ts
+++ b/src/events/runtime-events.ts
@@ -16,7 +16,7 @@ export interface RuntimeEventMap {
     taskId: string;
     agentId: string;
     toolName: string;
-    durationMs?: number;
+    durationMs: number;
   };
   "runtime.task.failed": {
     runtimeId: string;

--- a/tests/events/completion-duration.test.ts
+++ b/tests/events/completion-duration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { AgentRuntime, RuntimeEventBus } from "../../src/index.js";
+
+describe("runtime.task.completed duration", () => {
+  it("matches the completed event duration to the task result", async () => {
+    const eventBus = new RuntimeEventBus();
+    let eventDurationMs: number | undefined;
+
+    eventBus.on("runtime.task.completed", (event) => {
+      eventDurationMs = event.payload.durationMs;
+    });
+
+    const runtime = new AgentRuntime({
+      runtimeId: "runtime-completion-duration",
+      eventBus
+    });
+    runtime.registerTool({
+      name: "noop",
+      description: "Returns a static result.",
+      execute() {
+        return { ok: true };
+      }
+    });
+
+    await runtime.start();
+    const result = await runtime.executeTask({
+      taskId: "task-completion-duration",
+      agentId: "agent-completion-duration",
+      toolName: "noop",
+      input: "Run noop",
+      payload: {}
+    });
+
+    expect(eventDurationMs).toBe(result.durationMs);
+    expect(Number.isInteger(eventDurationMs)).toBe(true);
+    expect(eventDurationMs).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
Closes #234

Makes `durationMs` required on `runtime.task.completed` and adds a focused integration test confirming the event payload matches `TaskExecutionResult.durationMs` and is a non-negative integer.