### PR TITLE
fix(events): enforce the configured listener cap

### DIFF
--- a/src/events/runtime-events.ts
+++ b/src/events/runtime-events.ts
@@ -47,13 +47,27 @@ export type RuntimeEventListener<TName extends RuntimeEventName> = (
 ) => void;
 
 export interface RuntimeEventBusOptions {
-  /** Maximum listener registrations allowed per event name before warning. Defaults to 100. */
+  /** Maximum listener registrations allowed per event name. Defaults to 100. */
   maxListeners?: number;
   /** Optional handler invoked whenever a listener throws or rejects. */
   onListenerError?: (error: unknown) => void;
 }
 
 export const DEFAULT_MAX_LISTENERS = 100;
+
+export class RuntimeEventListenerLimitError extends Error {
+  public readonly eventName: RuntimeEventName;
+  public readonly maxListeners: number;
+
+  public constructor(eventName: RuntimeEventName, maxListeners: number) {
+    super(
+      `Cannot add listener for "${eventName}": max listener count (${maxListeners}) exceeded.`
+    );
+    this.name = "RuntimeEventListenerLimitError";
+    this.eventName = eventName;
+    this.maxListeners = maxListeners;
+  }
+}
 
 type Listener = RuntimeEventListener<RuntimeEventName>;
 
@@ -96,9 +110,7 @@ export class RuntimeEventBus {
     }
 
     if (listenerSet.size >= this.maxListeners) {
-      console.warn(
-        `[RuntimeEventBus] Possible memory leak: max listener count (${this.maxListeners}) exceeded for event "${eventName}".`
-      );
+      throw new RuntimeEventListenerLimitError(eventName, this.maxListeners);
     }
 
     listenerSet.add(stored);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,10 @@ export {
 } from "./agents/agent-instance-manager.js";
 export { ActionExecutor } from "./actions/action-executor.js";
 export { RuntimeError } from "./errors/runtime-errors.js";
-export { RuntimeEventBus } from "./events/runtime-events.js";
+export {
+  RuntimeEventBus,
+  RuntimeEventListenerLimitError
+} from "./events/runtime-events.js";
 export {
   assertMaxToolCalls,
   assertNonEmptyValue,

--- a/tests/events/max-listener-guard.test.ts
+++ b/tests/events/max-listener-guard.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
-import { RuntimeEventBus } from "../../src/events/runtime-events.js";
+import { describe, expect, it } from "vitest";
+import {
+  RuntimeEventBus,
+  RuntimeEventListenerLimitError
+} from "../../src/index.js";
 
 describe("RuntimeEventBus max-listener guard", () => {
   it("listenerCount returns 0 for unknown events", () => {
@@ -22,53 +25,42 @@ describe("RuntimeEventBus max-listener guard", () => {
     expect(bus.listenerCount("runtime.started")).toBe(0);
   });
 
-  it("warns when max listeners exceeded", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("throws without exceeding the configured max listeners", () => {
     const bus = new RuntimeEventBus({ maxListeners: 3 });
 
     bus.on("runtime.started", () => {});
     bus.on("runtime.started", () => {});
     bus.on("runtime.started", () => {});
-    // 4th listener should trigger warning
-    bus.on("runtime.started", () => {});
 
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0]![0]).toContain(
-      "max listener count (3) exceeded"
+    expect(() => bus.on("runtime.started", () => {})).toThrow(
+      RuntimeEventListenerLimitError
     );
-    expect(warnSpy.mock.calls[0]![0]).toContain("runtime.started");
-
-    warnSpy.mockRestore();
+    expect(() => bus.on("runtime.started", () => {})).toThrow(
+      'Cannot add listener for "runtime.started": max listener count (3) exceeded.'
+    );
+    expect(bus.listenerCount("runtime.started")).toBe(3);
   });
 
-  it("does not warn below the limit", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("allows registrations up to the configured limit", () => {
     const bus = new RuntimeEventBus({ maxListeners: 5 });
 
     for (let i = 0; i < 5; i++) {
       bus.on("runtime.started", () => {});
     }
 
-    expect(warnSpy).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
+    expect(bus.listenerCount("runtime.started")).toBe(5);
   });
 
-  it("uses default max of 100 when no option provided", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("enforces the default max of 100", () => {
     const bus = new RuntimeEventBus();
 
     for (let i = 0; i < 100; i++) {
       bus.on("runtime.started", () => {});
     }
-    expect(warnSpy).not.toHaveBeenCalled();
 
-    // 101st should warn
-    bus.on("runtime.started", () => {});
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0]![0]).toContain(
-      "max listener count (100) exceeded"
+    expect(() => bus.on("runtime.started", () => {})).toThrow(
+      RuntimeEventListenerLimitError
     );
-
-    warnSpy.mockRestore();
+    expect(bus.listenerCount("runtime.started")).toBe(100);
   });
 });


### PR DESCRIPTION
Closes #235

Restores `RuntimeEventListenerLimitError`, exports it from the package entry point, and throws before adding a listener once `maxListeners` is reached.

Updates the guard coverage to assert the listener count never exceeds the configured cap.