### PR TITLE
test(coverage): move source-local tests and exclude __tests__ from totals (#268)

### DIFF
--- a/tests/events/runtime-event-bus-listeners.test.ts
+++ b/tests/events/runtime-event-bus-listeners.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { RuntimeEventBus } from "../runtime-events.js";
+import { RuntimeEventBus } from "../../src/events/runtime-events.js";
 
 describe("RuntimeEventBus max listeners", () => {
   it("warns when exceeding maxListenersPerEvent", () => {

--- a/tests/events/runtime-internal-error.test.ts
+++ b/tests/events/runtime-internal-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { RuntimeEventBus } from "../runtime-events.js";
+import { RuntimeEventBus } from "../../src/events/runtime-events.js";
 
 describe("RuntimeEventBus runtime.internal.error", () => {
   it("emits runtime.internal.error when a listener throws", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
       exclude: [
+        "src/**/__tests__/**",
         "src/**/types.ts",
         "src/runtime/context.ts",
         "src/tasks/task-types.ts",


### PR DESCRIPTION
## Summary

Addresses #268 by moving the two event suites out of `src/events/__tests__` into the canonical top-level `tests/events` tree and adding an explicit `src/**/__tests__/**` coverage exclusion.

The moved suites use the repository's top-level import convention, no `src/**/__tests__` directory remains, and the explicit exclusion prevents future source-local test files from entering production coverage totals.

## Verification

The exact final patch was validated immediately before submission with the full `npm run verify` gate. Dependency preparation succeeded, offline dependency activation succeeded, and formatting, lint, TypeScript, Vitest and coverage all passed with network disabled during repository-code execution.

This independent submission combines relocation with an explicit future-proof coverage guard.

Closes #268