### PR TITLE
fix(actions): reject non-finite payment amounts (#239)

### DIFF
--- a/src/actions/payment-prep-action.ts
+++ b/src/actions/payment-prep-action.ts
@@ -52,10 +52,10 @@ export function createPaymentPrepTool(): ToolDefinition<
 
       const amountStr = String(payload.amount);
       const parsedAmount = Number(amountStr);
-      if (Number.isNaN(parsedAmount) || parsedAmount <= 0) {
+      if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
         throw new RuntimeError(
           "INVALID_TASK",
-          "amount must be a positive number.",
+          "amount must be a positive finite number.",
           { amount: payload.amount }
         );
       }

--- a/tests/payment-prep-action.test.ts
+++ b/tests/payment-prep-action.test.ts
@@ -130,4 +130,45 @@ describe("PaymentPrepAction", () => {
       })
     ).toThrowError(RuntimeError);
   });
+
+  it.each(["Infinity", "NaN", "1e309"])(
+    "rejects non-finite amount %s with INVALID_TASK",
+    (amount) => {
+      const tool = createPaymentPrepTool();
+      const context = createMockContext(`task-nonfinite-${amount}`);
+
+      expect(() =>
+        tool.execute({
+          payload: {
+            walletId: "GWALLET123",
+            amount
+          },
+          context
+        })
+      ).toThrowError(
+        expect.objectContaining({
+          code: "INVALID_TASK",
+          details: { amount }
+        })
+      );
+    }
+  );
+
+  it.each(["10.5", 10, "0.01"])(
+    "accepts finite positive amount %s",
+    async (amount) => {
+      const tool = createPaymentPrepTool();
+      const context = createMockContext(`task-finite-${amount}`);
+
+      const result = await tool.execute({
+        payload: {
+          walletId: "GWALLET123",
+          amount
+        },
+        context
+      });
+
+      expect(result.status).toBe("prepared");
+    }
+  );
 });


### PR DESCRIPTION
## Summary

Addresses #239 by rejecting non-finite payment amounts before they enter the transaction-preparation path. `Infinity`, `NaN`, and overflow strings such as `1e309` now fail with the existing `INVALID_TASK` code while normal positive decimal amounts remain valid.

Regression coverage checks all required non-finite inputs and representative valid positive string and numeric amounts.

## Verification

The exact patch was normalized with the repository's own Prettier version, then a ToolDefinition sync-or-Promise type issue in the positive regression was repaired by awaiting the execution result. The final exact patch passed the complete `npm run verify` suite, including formatting, ESLint, TypeScript, Vitest and coverage, with repository execution network-disabled.

This is an independent competing submission for the still-open bounty.

Closes #239