### PR TITLE
feat(logger): add level filtering and secret redaction to InMemoryRuntimeLogger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export type {
 } from "./events/runtime-events.js";
 export type {
   ConsoleRuntimeLoggerOptions,
+  InMemoryRuntimeLoggerOptions,
   RuntimeLogger,
   RuntimeLogLevel
 } from "./logger/runtime-logger.js";

--- a/src/logger/runtime-logger.ts
+++ b/src/logger/runtime-logger.ts
@@ -95,7 +95,12 @@ export class ConsoleRuntimeLogger implements RuntimeLogger {
 }
 
 export interface InMemoryRuntimeLoggerOptions {
+  /** Maximum number of entries to retain. Oldest entries are evicted first. Defaults to 5 000. */
   maxEntries?: number;
+  /** Minimum severity level to record. Entries below this level are silently discarded. When omitted, all levels are recorded. */
+  level?: RuntimeLogLevel;
+  /** Regex matched against metadata keys; matching values are replaced with `"[REDACTED]"`. Defaults to `DEFAULT_REDACT_KEYS`. Pass a regex that matches nothing (e.g. `/$^/`) to disable redaction. */
+  redactKeys?: RegExp;
 }
 
 interface InMemoryLogEntry {
@@ -107,25 +112,37 @@ interface InMemoryLogEntry {
 export class InMemoryRuntimeLogger implements RuntimeLogger {
   public readonly entries: InMemoryLogEntry[] = [];
   private readonly maxEntries: number;
+  private readonly minimumLevel: RuntimeLogLevel | undefined;
+  private readonly redactKeys: RegExp;
 
   public constructor(options: InMemoryRuntimeLoggerOptions = {}) {
     this.maxEntries = options.maxEntries ?? 5_000;
+    this.minimumLevel = options.level;
+    this.redactKeys = options.redactKeys ?? DEFAULT_REDACT_KEYS;
   }
 
   public info(message: string, metadata?: Record<string, unknown>): void {
-    this.appendEntry("info", message, metadata);
+    if (this.shouldLog("info")) {
+      this.appendEntry("info", message, metadata);
+    }
   }
 
   public warn(message: string, metadata?: Record<string, unknown>): void {
-    this.appendEntry("warn", message, metadata);
+    if (this.shouldLog("warn")) {
+      this.appendEntry("warn", message, metadata);
+    }
   }
 
   public debug(message: string, metadata?: Record<string, unknown>): void {
-    this.appendEntry("debug", message, metadata);
+    if (this.shouldLog("debug")) {
+      this.appendEntry("debug", message, metadata);
+    }
   }
 
   public error(message: string, metadata?: Record<string, unknown>): void {
-    this.appendEntry("error", message, metadata);
+    if (this.shouldLog("error")) {
+      this.appendEntry("error", message, metadata);
+    }
   }
 
   public clear(): void {
@@ -136,6 +153,13 @@ export class InMemoryRuntimeLogger implements RuntimeLogger {
     return this.entries.length;
   }
 
+  private shouldLog(level: RuntimeLogLevel): boolean {
+    if (this.minimumLevel === undefined) {
+      return true;
+    }
+    return LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[this.minimumLevel];
+  }
+
   private appendEntry(
     level: RuntimeLogLevel,
     message: string,
@@ -144,6 +168,11 @@ export class InMemoryRuntimeLogger implements RuntimeLogger {
     if (this.maxEntries > 0 && this.entries.length >= this.maxEntries) {
       this.entries.shift();
     }
-    this.entries.push({ level, message, metadata });
+    const redactedMetadata = metadata
+      ? (redactValue(metadata, this.redactKeys) as
+          | Record<string, unknown>
+          | undefined)
+      : undefined;
+    this.entries.push({ level, message, metadata: redactedMetadata });
   }
 }

--- a/tests/logger/in-memory-logger-level.test.ts
+++ b/tests/logger/in-memory-logger-level.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { InMemoryRuntimeLogger } from "../../src/logger/runtime-logger.js";
+
+describe("InMemoryRuntimeLogger level filtering", () => {
+  it("records only warn and error when level is 'warn'", () => {
+    const logger = new InMemoryRuntimeLogger({ level: "warn" });
+
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(logger.entries).toHaveLength(2);
+    expect(logger.entries.map((e) => e.level)).toEqual(["warn", "error"]);
+  });
+
+  it("records only error when level is 'error'", () => {
+    const logger = new InMemoryRuntimeLogger({ level: "error" });
+
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(logger.entries).toHaveLength(1);
+    expect(logger.entries[0]!.level).toBe("error");
+    expect(logger.entries[0]!.message).toBe("e");
+  });
+
+  it("records all levels when level is 'debug'", () => {
+    const logger = new InMemoryRuntimeLogger({ level: "debug" });
+
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(logger.entries).toHaveLength(4);
+    expect(logger.entries.map((e) => e.level)).toEqual([
+      "debug",
+      "info",
+      "warn",
+      "error"
+    ]);
+  });
+
+  it("records all levels when no level option is provided (default)", () => {
+    const logger = new InMemoryRuntimeLogger();
+
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(logger.entries).toHaveLength(4);
+    expect(logger.entries.map((e) => e.level)).toEqual([
+      "debug",
+      "info",
+      "warn",
+      "error"
+    ]);
+  });
+
+  it("size() reflects only retained entries after filtering", () => {
+    const logger = new InMemoryRuntimeLogger({ level: "warn" });
+
+    logger.debug("ignored");
+    logger.info("ignored");
+    logger.warn("kept");
+    logger.error("kept");
+
+    expect(logger.size()).toBe(2);
+  });
+
+  it("records info, warn, and error when level is 'info'", () => {
+    const logger = new InMemoryRuntimeLogger({ level: "info" });
+
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(logger.entries).toHaveLength(3);
+    expect(logger.entries.map((e) => e.level)).toEqual([
+      "info",
+      "warn",
+      "error"
+    ]);
+  });
+});

--- a/tests/logger/in-memory-logger-redaction.test.ts
+++ b/tests/logger/in-memory-logger-redaction.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { InMemoryRuntimeLogger } from "../../src/logger/runtime-logger.js";
+
+describe("InMemoryRuntimeLogger redaction", () => {
+  it("redacts default sensitive keys in metadata", () => {
+    const logger = new InMemoryRuntimeLogger();
+
+    logger.info("test", {
+      apiKey: "sk-live-xxx",
+      password: "hunter2",
+      token: "tok-123",
+      nested: { secret: "my-secret" }
+    });
+
+    const meta = logger.entries[0]!.metadata as Record<string, unknown>;
+    expect(meta.apiKey).toBe("[REDACTED]");
+    expect(meta.password).toBe("[REDACTED]");
+    expect(meta.token).toBe("[REDACTED]");
+    expect((meta.nested as Record<string, unknown>).secret).toBe("[REDACTED]");
+  });
+
+  it("passes non-sensitive keys through unchanged", () => {
+    const logger = new InMemoryRuntimeLogger();
+
+    logger.info("test", {
+      userId: "u1",
+      taskId: "t1",
+      apiKey: "leaked"
+    });
+
+    const meta = logger.entries[0]!.metadata as Record<string, unknown>;
+    expect(meta.userId).toBe("u1");
+    expect(meta.taskId).toBe("t1");
+    expect(meta.apiKey).toBe("[REDACTED]");
+  });
+
+  it("honors a custom redactKeys regex", () => {
+    const logger = new InMemoryRuntimeLogger({ redactKeys: /^ssn$/i });
+
+    logger.info("test", {
+      ssn: "123-45-6789",
+      name: "Alice",
+      token: "visible-token"
+    });
+
+    const meta = logger.entries[0]!.metadata as Record<string, unknown>;
+    expect(meta.ssn).toBe("[REDACTED]");
+    expect(meta.name).toBe("Alice");
+    expect(meta.token).toBe("visible-token");
+  });
+
+  it("applies redaction to all four log levels", () => {
+    const logger = new InMemoryRuntimeLogger();
+    const sensitive = { password: "secret123", safe: "visible" };
+
+    logger.info("i", { ...sensitive });
+    logger.warn("w", { ...sensitive });
+    logger.debug("d", { ...sensitive });
+    logger.error("e", { ...sensitive });
+
+    for (const entry of logger.entries) {
+      const meta = entry.metadata as Record<string, unknown>;
+      expect(meta.password).toBe("[REDACTED]");
+      expect(meta.safe).toBe("visible");
+    }
+  });
+
+  it("handles undefined metadata gracefully", () => {
+    const logger = new InMemoryRuntimeLogger();
+
+    logger.info("no meta");
+
+    expect(logger.entries[0]!.metadata).toBeUndefined();
+  });
+
+  it("redacts nested objects recursively", () => {
+    const logger = new InMemoryRuntimeLogger();
+
+    logger.info("nested", {
+      user: {
+        name: "Bob",
+        credentials: {
+          password: "secret",
+          apiKey: "sk-xxx"
+        }
+      },
+      safe: "value"
+    });
+
+    const meta = logger.entries[0]!.metadata as Record<string, unknown>;
+    expect(meta.user).toEqual({
+      name: "Bob",
+      credentials: {
+        password: "[REDACTED]",
+        apiKey: "[REDACTED]"
+      }
+    });
+    expect(meta.safe).toBe("value");
+  });
+
+  it("redacts authorization and secretKey via default pattern", () => {
+    const logger = new InMemoryRuntimeLogger();
+
+    logger.error("auth test", {
+      authorization: "Bearer xyz",
+      secretKey: "my-secret",
+      normalField: "visible"
+    });
+
+    const meta = logger.entries[0]!.metadata as Record<string, unknown>;
+    expect(meta.authorization).toBe("[REDACTED]");
+    expect(meta.secretKey).toBe("[REDACTED]");
+    expect(meta.normalField).toBe("visible");
+  });
+});


### PR DESCRIPTION
## Summary
Closes #265
Closes #266

## Changes
- Add `level` and `redactKeys` options to `InMemoryRuntimeLoggerOptions` and export from root.
- Implement `shouldLog()` filtering in `InMemoryRuntimeLogger` matching `ConsoleRuntimeLogger`.
- Apply secret redaction via `redactValue()` to entries in `appendEntry()`.
- Add 13 unit tests covering level filtering and redaction behavior.

## Testing
- `npm run typecheck` passes cleanly.
- `npm run test` passes (238/239 tests pass; 1 pre-existing fast-check bug).
- `prettier` and `eslint` pass cleanly.

## Payout Details
- **Designated Solana (SOL / USDC) Payout Wallet**: `83zVPhcPEjsdBog2v8foVtCPiFqaW9LwK366FiVv1Uh`
- **PayPal**: `potularanadheer@gmail.com`
