### PR TITLE
fix(logger): restore ConsoleRuntimeLogger warn level filtering (Closes #231)

### DIFF
--- a/src/logger/runtime-logger.ts
+++ b/src/logger/runtime-logger.ts
@@ -48,40 +48,58 @@ function redactValue(value: unknown, redactKeys: RegExp): unknown {
 }
 
 export class ConsoleRuntimeLogger implements RuntimeLogger {
-  private readonly minimumLevel: RuntimeLogLevel;
+  public readonly level: RuntimeLogLevel;
   private readonly redactKeys: RegExp;
 
   public constructor(options: ConsoleRuntimeLoggerOptions = {}) {
-    this.minimumLevel = options.level ?? "info";
+    this.level = options.level ?? "info";
     this.redactKeys = options.redactKeys ?? DEFAULT_REDACT_KEYS;
   }
 
   public info(message: string, metadata?: Record<string, unknown>): void {
-    if (this.shouldLog("info")) {
-      console.info(message, this.prepareMetadata(metadata));
-    }
+    this.emit("info", message, metadata);
   }
 
   public warn(message: string, metadata?: Record<string, unknown>): void {
-    if (this.shouldLog("warn")) {
-      console.warn(message, this.prepareMetadata(metadata));
-    }
+    this.emit("warn", message, metadata);
   }
 
   public debug(message: string, metadata?: Record<string, unknown>): void {
-    if (this.shouldLog("debug")) {
-      console.debug(message, this.prepareMetadata(metadata));
-    }
+    this.emit("debug", message, metadata);
   }
 
   public error(message: string, metadata?: Record<string, unknown>): void {
-    if (this.shouldLog("error")) {
-      console.error(message, this.prepareMetadata(metadata));
+    this.emit("error", message, metadata);
+  }
+
+  private emit(
+    level: RuntimeLogLevel,
+    message: string,
+    metadata?: Record<string, unknown>
+  ): void {
+    if (!this.shouldLog(level)) {
+      return;
+    }
+
+    const prepared = this.prepareMetadata(metadata);
+    switch (level) {
+      case "debug":
+        console.debug(message, prepared);
+        break;
+      case "info":
+        console.info(message, prepared);
+        break;
+      case "warn":
+        console.warn(message, prepared);
+        break;
+      case "error":
+        console.error(message, prepared);
+        break;
     }
   }
 
   private shouldLog(level: RuntimeLogLevel): boolean {
-    return LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[this.minimumLevel];
+    return LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[this.level];
   }
 
   private prepareMetadata(

--- a/tests/logger/issue-231-console-logger.test.ts
+++ b/tests/logger/issue-231-console-logger.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConsoleRuntimeLogger } from "../../src/logger/runtime-logger.js";
+
+describe("ConsoleRuntimeLogger warn dedup + level filtering (Issue #231)", () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("exposes a single warn method on the prototype", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      ConsoleRuntimeLogger.prototype,
+      "warn"
+    );
+    expect(descriptor).toBeDefined();
+    expect(typeof descriptor?.value).toBe("function");
+  });
+
+  it("with level error, warn makes no console.warn call", () => {
+    const logger = new ConsoleRuntimeLogger({ level: "error" });
+    expect(logger.level).toBe("error");
+
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith("e", {});
+  });
+
+  it("with level warn, info is suppressed while warn and error print", () => {
+    const logger = new ConsoleRuntimeLogger({ level: "warn" });
+    expect(logger.level).toBe("warn");
+
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith("w", {});
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith("e", {});
+  });
+
+  it("routes every level through the same shouldLog gate", () => {
+    const logger = new ConsoleRuntimeLogger({ level: "info" });
+    logger.debug("hidden");
+    logger.info("shown-info");
+    logger.warn("shown-warn");
+    logger.error("shown-error");
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Route all ConsoleRuntimeLogger levels through a single emit/shouldLog gate so warn cannot bypass filtering. Expose readonly level. Adds regression tests for level=error and level=warn. Closes #231.