### PR TITLE
test(coverage): exclude src/**/__tests__ from Vitest totals (Closes #268)

### DIFF
--- a/tests/events/runtime-events-src-moved.test.ts
+++ b/tests/events/runtime-events-src-moved.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { RuntimeEventBus } from "../runtime-events.js";
+import { RuntimeEventBus } from "../../src/events/runtime-events.js";
 
 describe("RuntimeEventBus max listeners", () => {
   it("warns when exceeding maxListenersPerEvent", () => {

--- a/tests/events/runtime-internal-error-src-moved.test.ts
+++ b/tests/events/runtime-internal-error-src-moved.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { RuntimeEventBus } from "../runtime-events.js";
+import { RuntimeEventBus } from "../../src/events/runtime-events.js";
 
 describe("RuntimeEventBus runtime.internal.error", () => {
   it("emits runtime.internal.error when a listener throws", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
       exclude: [
+        "src/**/__tests__/**",
         "src/**/types.ts",
         "src/runtime/context.ts",
         "src/tasks/task-types.ts",


### PR DESCRIPTION
Move src/events/__tests__ suites into tests/events and add src/**/__tests__/** to coverage.exclude so thresholds cover production code only. No src/**/__tests__ directory remains. Closes #268.