### PR TITLE
fix: exclude __tests__ from Vitest coverage (#268)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
         "src/runtime/context.ts",
         "src/tasks/task-types.ts",
         "src/providers/model-provider.ts",
-        "src/state/runtime-state.ts"
+        "src/state/runtime-state.ts",
+        "src/**/__tests__/**"
       ],
       thresholds: {
         lines: 85,


### PR DESCRIPTION
## Summary

Exclude `src/**/__tests__/**` from Vitest coverage to prevent test files from inflating coverage metrics.

## Changes

- Added `"src/**/__tests__/**"` to the `coverage.exclude` array in `vitest.config.ts`

## Testing

Test files in `src/events/__tests__/` are no longer included in coverage reports.

## Related Issue

Fixes #268

---

💰 Bounty: $50
