### PR TITLE
fix(provider): reject malformed chat completion responses

### DIFF
--- a/src/providers/openai-compatible-provider.ts
+++ b/src/providers/openai-compatible-provider.ts
@@ -4,6 +4,10 @@ import type {
   ModelResponse
 } from "./model-provider.js";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export interface OpenAICompatibleProviderOptions {
   apiKey: string;
   baseUrl?: string | undefined;
@@ -98,24 +102,57 @@ export class OpenAICompatibleModelProvider implements ModelProvider {
       );
     }
 
-    const data = (await response.json()) as {
-      choices?: Array<{
-        message?: {
-          content?: string;
-        };
-        finish_reason?: string;
-      }>;
-      usage?: Record<string, unknown>;
-      model?: string;
-    };
+    let responseText: string;
+    try {
+      responseText = await response.text();
+    } catch (error) {
+      throw new Error(
+        `OpenAI-compatible provider could not read HTTP ${response.status} response body.`,
+        { cause: error }
+      );
+    }
 
-    const outputText = data.choices?.[0]?.message?.content ?? "";
+    let data: unknown;
+    try {
+      data = JSON.parse(responseText) as unknown;
+    } catch (error) {
+      const excerpt = JSON.stringify(responseText.slice(0, 200));
+      throw new Error(
+        `OpenAI-compatible provider returned invalid JSON (HTTP ${response.status}): ${excerpt}${responseText.length > 200 ? "..." : ""}`,
+        { cause: error }
+      );
+    }
+
+    if (
+      !isRecord(data) ||
+      !Array.isArray(data.choices) ||
+      data.choices.length === 0
+    ) {
+      throw new Error(
+        `OpenAI-compatible provider returned malformed response (HTTP ${response.status}): expected a non-empty choices array.`
+      );
+    }
+
+    const choice: unknown = data.choices[0];
+    if (
+      !isRecord(choice) ||
+      !isRecord(choice.message) ||
+      typeof choice.message.content !== "string"
+    ) {
+      throw new Error(
+        `OpenAI-compatible provider returned malformed response (HTTP ${response.status}): expected choices[0].message.content to be a string.`
+      );
+    }
+
+    // Explicit empty strings are valid text responses. Missing/null content,
+    // including tool-call-only completions, cannot satisfy this text-only API.
+    const outputText = choice.message.content;
     const metadata: Record<string, unknown> = {
       model: data.model ?? this.model
     };
 
-    if (data.choices?.[0]?.finish_reason !== undefined) {
-      metadata.finishReason = data.choices[0].finish_reason;
+    if (choice.finish_reason !== undefined) {
+      metadata.finishReason = choice.finish_reason;
     }
     if (data.usage !== undefined) {
       metadata.usage = data.usage;

--- a/tests/openai-compatible-provider.test.ts
+++ b/tests/openai-compatible-provider.test.ts
@@ -186,4 +186,102 @@ describe("OpenAICompatibleModelProvider", () => {
       "OpenAI-compatible provider request failed: ECONNREFUSED"
     );
   });
+
+  it.each([null, [], {}, { choices: null }, { choices: {} }, { choices: [] }])(
+    "rejects a successful HTTP response without a non-empty choices array: %j",
+    async (payload) => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify(payload), { status: 200 })
+      );
+      const provider = new OpenAICompatibleModelProvider({
+        apiKey: "test-key"
+      });
+
+      await expect(
+        provider.generate({ instructions: "test", input: "test" })
+      ).rejects.toThrowError(
+        "malformed response (HTTP 200): expected a non-empty choices array."
+      );
+    }
+  );
+
+  it.each([
+    null,
+    {},
+    { message: null },
+    { message: {} },
+    { message: { content: null }, finish_reason: "tool_calls" },
+    { message: { content: 123 } }
+  ])("rejects a choice without string message content: %j", async (choice) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ choices: [choice] }), { status: 200 })
+    );
+    const provider = new OpenAICompatibleModelProvider({ apiKey: "test-key" });
+
+    await expect(
+      provider.generate({ instructions: "test", input: "test" })
+    ).rejects.toThrowError(
+      "malformed response (HTTP 200): expected choices[0].message.content to be a string."
+    );
+  });
+
+  it("preserves an explicitly empty string and completion metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "" }, finish_reason: "stop" }],
+          usage: { total_tokens: 1 }
+        }),
+        { status: 200 }
+      )
+    );
+    const provider = new OpenAICompatibleModelProvider({ apiKey: "test-key" });
+
+    await expect(
+      provider.generate({ instructions: "test", input: "test" })
+    ).resolves.toEqual({
+      outputText: "",
+      metadata: {
+        model: "gpt-4o-mini",
+        finishReason: "stop",
+        usage: { total_tokens: 1 }
+      }
+    });
+  });
+
+  it("wraps malformed JSON with HTTP context and a bounded body excerpt", async () => {
+    const body =
+      "<html>upstream error</html>\n" + "x".repeat(300) + "AFTER_LIMIT";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(body, { status: 200 })
+    );
+    const provider = new OpenAICompatibleModelProvider({ apiKey: "test-key" });
+
+    const failure = await provider
+      .generate({ instructions: "test", input: "test" })
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toBe(
+      `OpenAI-compatible provider returned invalid JSON (HTTP 200): ${JSON.stringify(body.slice(0, 200))}...`
+    );
+    expect((failure as Error).message).not.toContain("AFTER_LIMIT");
+    expect((failure as Error).cause).toBeInstanceOf(SyntaxError);
+  });
+
+  it("preserves HTTP context when reading the successful response body fails", async () => {
+    const bodyFailure = new Error("connection closed during response");
+    const response = new Response("", { status: 200 });
+    vi.spyOn(response, "text").mockRejectedValueOnce(bodyFailure);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(response);
+    const provider = new OpenAICompatibleModelProvider({ apiKey: "test-key" });
+
+    await expect(
+      provider.generate({ instructions: "test", input: "test" })
+    ).rejects.toMatchObject({
+      message:
+        "OpenAI-compatible provider could not read HTTP 200 response body.",
+      cause: bodyFailure
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #267. A successful HTTP response with missing or empty `choices`, or missing/non-string message content, now rejects descriptively instead of becoming a successful empty `ModelResponse`. Invalid JSON errors include the HTTP status and a quoted, 200-character body excerpt; response-body read failures retain their cause.

Explicit string content, including `""`, remains valid. Null or missing content from a tool-call-only completion is rejected because this provider's API returns text. Existing model, finish-reason, and usage metadata are preserved.

## Validation

- `npx vitest run tests/openai-compatible-provider.test.ts`: 22 passed.
- `npm run verify`: passed after normalizing local checkout line endings for Prettier; 55 files / 241 tests passed, including success, non-2xx and network-failure paths.
- `npm run build`: passed.
- No live model requests; HTTP responses are controlled in tests.

## Checklist

- [x] Tests added or updated
- [x] Public interfaces remain intentionally extendable
- [x] Documentation updated where relevant (inline empty-output contract)
- [x] Scope stays focused on one architectural concern

Submitted for the advertised $90 bounty in #267. This is an AI-assisted contribution from Token Junkie Labs. Please confirm the payout method and timing if accepted; no award or payment is assumed.
