### PR TITLE
test(tasks): assert TaskRunner preserves RuntimeError codes, message, and details (closes #246)

### DIFF
--- a/tests/task-runner.test.ts
+++ b/tests/task-runner.test.ts
@@ -6,7 +6,9 @@ import {
   TaskRunner,
   ToolRegistry,
   UnconfiguredModelProvider,
-  InMemoryRuntimeStateStore
+  InMemoryRuntimeStateStore,
+  RuntimeError,
+  type RuntimeErrorCode
 } from "../src/index.js";
 
 describe("TaskRunner", () => {
@@ -47,6 +49,105 @@ describe("TaskRunner", () => {
       )
     ).rejects.toMatchObject({
       code: "EXECUTION_FAILED"
+    });
+  });
+
+  it("preserves tool-thrown RuntimeError code, message, and details without wrapping", async () => {
+    const customDetails = {
+      reason: "validation_constraint",
+      field: "amount",
+      value: -50
+    };
+    const customMessage =
+      "Payment authorization rejected due to invalid parameters";
+    const customCode: RuntimeErrorCode = "MAX_TOOL_CALLS_EXCEEDED";
+
+    const toolRegistry = new ToolRegistry();
+    toolRegistry.register({
+      name: "pay",
+      description: "Throws typed RuntimeError",
+      execute() {
+        throw new RuntimeError(customCode, customMessage, customDetails);
+      }
+    });
+
+    const runner = new TaskRunner(
+      new ActionExecutor(toolRegistry),
+      new InMemoryMemoryStore()
+    );
+    const agent = new AgentInstanceManager().getOrCreate("agent-1");
+
+    try {
+      await runner.run(
+        {
+          taskId: "task-typed-err",
+          agentId: "agent-1",
+          toolName: "pay",
+          input: "Send payment",
+          payload: {}
+        },
+        {
+          runtimeId: "runtime-1",
+          taskId: "task-typed-err",
+          agent,
+          memory: new InMemoryMemoryStore(),
+          modelProvider: new UnconfiguredModelProvider(),
+          state: new InMemoryRuntimeStateStore(),
+          now: new Date().toISOString()
+        }
+      );
+      expect.unreachable("should have thrown RuntimeError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(RuntimeError);
+      const err = error as RuntimeError;
+      expect(err.code).toBe(customCode);
+      expect(err.code).not.toBe("EXECUTION_FAILED");
+      expect(err.message).toBe(customMessage);
+      expect(err.details).toEqual(customDetails);
+    }
+  });
+
+  it("propagates standard RuntimeError instances directly", async () => {
+    const toolRegistry = new ToolRegistry();
+    toolRegistry.register({
+      name: "duplicate_tool",
+      description: "Throws DUPLICATE_TOOL",
+      execute() {
+        throw new RuntimeError("DUPLICATE_TOOL", "Tool already registered", {
+          toolName: "duplicate_tool"
+        });
+      }
+    });
+
+    const runner = new TaskRunner(
+      new ActionExecutor(toolRegistry),
+      new InMemoryMemoryStore()
+    );
+    const agent = new AgentInstanceManager().getOrCreate("agent-2");
+
+    await expect(
+      runner.run(
+        {
+          taskId: "task-dup",
+          agentId: "agent-2",
+          toolName: "duplicate_tool",
+          input: "Trigger duplicate tool error",
+          payload: {}
+        },
+        {
+          runtimeId: "runtime-1",
+          taskId: "task-dup",
+          agent,
+          memory: new InMemoryMemoryStore(),
+          modelProvider: new UnconfiguredModelProvider(),
+          state: new InMemoryRuntimeStateStore(),
+          now: new Date().toISOString()
+        }
+      )
+    ).rejects.toMatchObject({
+      code: "DUPLICATE_TOOL",
+      message: "Tool already registered",
+      details: { toolName: "duplicate_tool" }
     });
   });
 });


### PR DESCRIPTION
### Summary of Changes

Closes #246 ($55 USD bounty).

This PR adds unit tests verifying that `TaskRunner.run()` preserves `RuntimeError` instances thrown by tools without wrapping them into `EXECUTION_FAILED`:

1. **Typed Error Preservation Test**: Registers a tool throwing a `RuntimeError` with a distinctive `code`, `message`, and structured `details`, and asserts the rejection from `runner.run()` maintains the original `code`, `message`, and `details` intact.
2. **Standard RuntimeError Direct Propagation**: Asserts standard typed codes (e.g. `DUPLICATE_TOOL`) propagate directly to the caller.
3. **Existing Behavior Retained**: The existing test verifying that non-`RuntimeError` failures are safely wrapped into `EXECUTION_FAILED` continues to pass.

### Verification
- `npm run lint` passing (0 errors)
- `npm run typecheck` passing (0 errors)
- Formatted with Prettier (`npx prettier --check tests/task-runner.test.ts`)
- All unit tests in `tests/task-runner.test.ts` and `tests/tasks/task-runner.test.ts` passing (7/7)

Solana payout address: `GwGvT7jeUa9GPYYfSbnT2HRzTyZk6xeqs9EG7443tGi`
